### PR TITLE
Fix frontend API routing

### DIFF
--- a/docs/tictactoe.md
+++ b/docs/tictactoe.md
@@ -21,3 +21,4 @@ npm run dev
 ```
 
 Open the browser at `http://localhost:3000` to play. Click **New Game** to start and select a square to make your move. The computer opponent plays randomly.
+The Vite dev server forwards any `/tictactoe` requests to the backend running on `http://localhost:8000`, so no additional configuration is needed.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,3 +12,5 @@ npm run dev
 ```
 
 This will launch Vite and open the game at `http://localhost:3000`.
+All requests to paths starting with `/tictactoe` will be automatically
+proxied to the FastAPI backend running on `http://localhost:8000`.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,9 @@
 export default {
-  root: '.',
+  root: ".",
   server: {
-    port: 3000
-  }
+    port: 3000,
+    proxy: {
+      "/tictactoe": "http://localhost:8000",
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy `/tictactoe` API calls to the backend
- document the proxy behavior in the frontend README and Tic Tac Toe docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868add3ea2883239f52cdaa531ba8da