### PR TITLE
Add restart button and wall obstacles

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -11,4 +11,4 @@ npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. Red zombies spawn randomly and slowly move toward you. If a zombie touches you, the game ends.
+The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. Red zombies spawn randomly and slowly move toward you. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **Restart** button will appear so you can quickly try again without refreshing the page.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,7 @@
       height="400"
       style="border: 1px solid #000"
     ></canvas>
+    <button id="restartBtn" style="display: none">Restart</button>
     <p>Use WASD or arrow keys to move. Avoid the red zombies!</p>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -20,3 +20,40 @@ export function isColliding(a, b, radius) {
 export function spawnZombie(width, height) {
   return createZombie(Math.random() * width, Math.random() * height);
 }
+
+export const SEGMENT_SIZE = 40;
+
+export function generateWalls(width, height, count = 3) {
+  const walls = [];
+  const gridW = Math.floor(width / SEGMENT_SIZE);
+  const gridH = Math.floor(height / SEGMENT_SIZE);
+  for (let i = 0; i < count; i++) {
+    const pieces = 3 + Math.floor(Math.random() * 3); // 3-5
+    let gx = Math.floor(Math.random() * gridW);
+    let gy = Math.floor(Math.random() * gridH);
+    for (let p = 0; p < pieces; p++) {
+      walls.push({
+        x: gx * SEGMENT_SIZE,
+        y: gy * SEGMENT_SIZE,
+        size: SEGMENT_SIZE,
+      });
+      const dir = Math.random() < 0.5 ? "h" : "v";
+      if (dir === "h") {
+        gx += Math.random() < 0.5 ? -1 : 1;
+      } else {
+        gy += Math.random() < 0.5 ? -1 : 1;
+      }
+      gx = Math.max(0, Math.min(gridW - 1, gx));
+      gy = Math.max(0, Math.min(gridH - 1, gy));
+    }
+  }
+  return walls;
+}
+
+export function circleRectColliding(circle, rect, radius) {
+  const closestX = Math.max(rect.x, Math.min(circle.x, rect.x + rect.size));
+  const closestY = Math.max(rect.y, Math.min(circle.y, rect.y + rect.size));
+  const dx = circle.x - closestX;
+  const dy = circle.y - closestY;
+  return dx * dx + dy * dy < radius * radius;
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,13 +1,35 @@
-import { spawnZombie, moveTowards, isColliding } from "./game_logic.js";
+import {
+  spawnZombie,
+  moveTowards,
+  isColliding,
+  generateWalls,
+  circleRectColliding,
+  SEGMENT_SIZE,
+} from "./game_logic.js";
 
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
 
+const restartBtn = document.getElementById("restartBtn");
+
 const player = { x: canvas.width / 2, y: canvas.height / 2, speed: 2 };
-const zombies = [];
+let zombies = [];
+let walls = [];
 let spawnTimer = 0;
 let gameOver = false;
 const keys = {};
+
+function resetGame() {
+  player.x = canvas.width / 2;
+  player.y = canvas.height / 2;
+  zombies = [];
+  walls = generateWalls(canvas.width, canvas.height, 4);
+  spawnTimer = 0;
+  gameOver = false;
+  restartBtn.style.display = "none";
+}
+
+restartBtn.addEventListener("click", resetGame);
 
 window.addEventListener("keydown", (e) => {
   keys[e.key.toLowerCase()] = true;
@@ -19,6 +41,9 @@ window.addEventListener("keyup", (e) => {
 function update() {
   if (gameOver) return;
 
+  const prevX = player.x;
+  const prevY = player.y;
+
   if (keys["arrowup"] || keys["w"]) player.y -= player.speed;
   if (keys["arrowdown"] || keys["s"]) player.y += player.speed;
   if (keys["arrowleft"] || keys["a"]) player.x -= player.speed;
@@ -26,6 +51,11 @@ function update() {
 
   player.x = Math.max(10, Math.min(canvas.width - 10, player.x));
   player.y = Math.max(10, Math.min(canvas.height - 10, player.y));
+
+  if (walls.some((w) => circleRectColliding(player, w, 10))) {
+    player.x = prevX;
+    player.y = prevY;
+  }
 
   if (spawnTimer <= 0) {
     zombies.push(spawnZombie(canvas.width, canvas.height));
@@ -35,15 +65,27 @@ function update() {
   }
 
   zombies.forEach((z) => {
+    const zx = z.x;
+    const zy = z.y;
     moveTowards(z, player, 1);
+    if (walls.some((w) => circleRectColliding(z, w, 10))) {
+      z.x = zx;
+      z.y = zy;
+    }
     if (isColliding(z, player, 10)) {
       gameOver = true;
+      restartBtn.style.display = "block";
     }
   });
 }
 
 function render() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = "gray";
+  walls.forEach((w) => {
+    ctx.fillRect(w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
+  });
 
   ctx.fillStyle = "green";
   ctx.beginPath();
@@ -62,6 +104,7 @@ function render() {
     ctx.font = "32px sans-serif";
     ctx.textAlign = "center";
     ctx.fillText("Game Over", canvas.width / 2, canvas.height / 2);
+    restartBtn.style.display = "block";
   }
 }
 
@@ -71,4 +114,7 @@ function gameLoop() {
   requestAnimationFrame(gameLoop);
 }
 
-window.addEventListener("load", gameLoop);
+window.addEventListener("load", () => {
+  resetGame();
+  gameLoop();
+});

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { moveTowards, isColliding } from "../src/game_logic.js";
+import {
+  moveTowards,
+  isColliding,
+  generateWalls,
+  circleRectColliding,
+  SEGMENT_SIZE,
+} from "../src/game_logic.js";
 
 test("moveTowards moves entity toward target", () => {
   const zombie = { x: 0, y: 0 };
@@ -16,4 +22,22 @@ test("isColliding detects overlap", () => {
   assert.strictEqual(isColliding(a, b, 3), true);
   const c = { x: 7, y: 0 };
   assert.strictEqual(isColliding(a, c, 3), false);
+});
+
+test("generateWalls creates segments within bounds", () => {
+  const walls = generateWalls(100, 100, 1);
+  assert(walls.length >= 3 && walls.length <= 5);
+  walls.forEach((w) => {
+    assert(w.x >= 0 && w.x + w.size <= 100);
+    assert(w.y >= 0 && w.y + w.size <= 100);
+    assert.strictEqual(w.size, SEGMENT_SIZE);
+  });
+});
+
+test("circleRectColliding detects intersection", () => {
+  const rect = { x: 40, y: 40, size: SEGMENT_SIZE };
+  const circle = { x: 50, y: 50 };
+  assert.strictEqual(circleRectColliding(circle, rect, 10), true);
+  const far = { x: 10, y: 10 };
+  assert.strictEqual(circleRectColliding(far, rect, 10), false);
 });


### PR DESCRIPTION
## Summary
- add Restart button on the game page
- implement wall generation and collision detection
- block players/zombies with walls and show button when game ends
- update zombie game docs
- test new wall utilities

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868b474408883238f4e6db8f99b929d