### PR TITLE
Improve zombie navigation around walls

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -11,4 +11,4 @@ npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. Red zombies spawn randomly and slowly move toward you. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **Restart** button will appear so you can quickly try again without refreshing the page.
+The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. Red zombies spawn around the map (never inside walls) and will now navigate around obstacles to reach you. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **Restart** button will appear so you can quickly try again without refreshing the page.

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -17,8 +17,17 @@ export function isColliding(a, b, radius) {
   return Math.hypot(dx, dy) < radius * 2;
 }
 
-export function spawnZombie(width, height) {
-  return createZombie(Math.random() * width, Math.random() * height);
+export function spawnZombie(width, height, walls = []) {
+  let zombie;
+  let attempts = 0;
+  do {
+    zombie = createZombie(Math.random() * width, Math.random() * height);
+    attempts++;
+  } while (
+    attempts < 20 &&
+    walls.some((w) => circleRectColliding(zombie, w, 10))
+  );
+  return zombie;
 }
 
 export const SEGMENT_SIZE = 40;
@@ -56,4 +65,62 @@ export function circleRectColliding(circle, rect, radius) {
   const dx = circle.x - closestX;
   const dy = circle.y - closestY;
   return dx * dx + dy * dy < radius * radius;
+}
+
+export function findPath(start, goal, walls, width, height) {
+  const gridW = Math.floor(width / SEGMENT_SIZE);
+  const gridH = Math.floor(height / SEGMENT_SIZE);
+  const sx = Math.floor(start.x / SEGMENT_SIZE);
+  const sy = Math.floor(start.y / SEGMENT_SIZE);
+  const gx = Math.floor(goal.x / SEGMENT_SIZE);
+  const gy = Math.floor(goal.y / SEGMENT_SIZE);
+  const blocked = new Set(
+    walls.map((w) => `${w.x / SEGMENT_SIZE},${w.y / SEGMENT_SIZE}`),
+  );
+  const queue = [[sx, sy]];
+  const key = (x, y) => `${x},${y}`;
+  const cameFrom = new Map([[key(sx, sy), null]]);
+  const dirs = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ];
+  while (queue.length) {
+    const [cx, cy] = queue.shift();
+    if (cx === gx && cy === gy) break;
+    for (const [dx, dy] of dirs) {
+      const nx = cx + dx;
+      const ny = cy + dy;
+      if (nx < 0 || ny < 0 || nx >= gridW || ny >= gridH) continue;
+      const nKey = key(nx, ny);
+      if (blocked.has(nKey) || cameFrom.has(nKey)) continue;
+      cameFrom.set(nKey, [cx, cy]);
+      queue.push([nx, ny]);
+    }
+  }
+
+  const path = [];
+  let cur = [gx, gy];
+  while (cur) {
+    path.unshift(cur);
+    const parent = cameFrom.get(key(cur[0], cur[1]));
+    cur = parent || null;
+  }
+  if (path[0][0] !== sx || path[0][1] !== sy) return [];
+  return path;
+}
+
+export function moveZombie(zombie, player, walls, speed, width, height) {
+  const path = findPath(zombie, player, walls, width, height);
+  if (path.length > 1) {
+    const [nx, ny] = path[1];
+    const target = {
+      x: nx * SEGMENT_SIZE + SEGMENT_SIZE / 2,
+      y: ny * SEGMENT_SIZE + SEGMENT_SIZE / 2,
+    };
+    moveTowards(zombie, target, speed);
+  } else {
+    moveTowards(zombie, player, speed);
+  }
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,6 @@
 import {
   spawnZombie,
+  moveZombie,
   moveTowards,
   isColliding,
   generateWalls,
@@ -58,19 +59,17 @@ function update() {
   }
 
   if (spawnTimer <= 0) {
-    zombies.push(spawnZombie(canvas.width, canvas.height));
+    zombies.push(spawnZombie(canvas.width, canvas.height, walls));
     spawnTimer = 60;
   } else {
     spawnTimer--;
   }
 
   zombies.forEach((z) => {
-    const zx = z.x;
-    const zy = z.y;
-    moveTowards(z, player, 1);
+    moveZombie(z, player, walls, 1, canvas.width, canvas.height);
     if (walls.some((w) => circleRectColliding(z, w, 10))) {
-      z.x = zx;
-      z.y = zy;
+      // fallback in case of pathfinding error
+      moveTowards(z, player, 1);
     }
     if (isColliding(z, player, 10)) {
       gameOver = true;

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -6,6 +6,8 @@ import {
   generateWalls,
   circleRectColliding,
   SEGMENT_SIZE,
+  spawnZombie,
+  findPath,
 } from "../src/game_logic.js";
 
 test("moveTowards moves entity toward target", () => {
@@ -40,4 +42,26 @@ test("circleRectColliding detects intersection", () => {
   assert.strictEqual(circleRectColliding(circle, rect, 10), true);
   const far = { x: 10, y: 10 };
   assert.strictEqual(circleRectColliding(far, rect, 10), false);
+});
+
+test("spawnZombie avoids walls", () => {
+  const wall = { x: 40, y: 40, size: SEGMENT_SIZE };
+  for (let i = 0; i < 20; i++) {
+    const z = spawnZombie(80, 80, [wall]);
+    assert.strictEqual(circleRectColliding(z, wall, 10), false);
+  }
+});
+
+test("findPath navigates around walls", () => {
+  const walls = [{ x: 40, y: 0, size: SEGMENT_SIZE }];
+  const start = { x: 10, y: 10 };
+  const end = { x: 90, y: 50 };
+  const path = findPath(start, end, walls, 120, 80);
+  assert(path.length > 0);
+  const blocked = new Set(
+    walls.map((w) => `${w.x / SEGMENT_SIZE},${w.y / SEGMENT_SIZE}`),
+  );
+  path.forEach((c) => {
+    assert.strictEqual(blocked.has(`${c[0]},${c[1]}`), false);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent zombies from spawning inside walls
- pathfind around obstacles so zombies don't get stuck
- update docs for new zombie behavior
- test new spawn and pathfinding helpers

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b6f3b104832390febfe65e0f203b