### PR TITLE
Improve zombie path with line-of-sight

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -5,10 +5,11 @@ This repository includes a minimal zombie survival demo to showcase basic canvas
 ## Running the Example
 
 ### Frontend
+
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. Red zombies spawn randomly and slowly move toward you. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **Restart** button will appear so you can quickly try again without refreshing the page.
+The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. Red zombies spawn around the map (never inside walls). They charge straight toward the player whenever they have a clear line of sight, otherwise they calculate a short path around any blocking walls. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **Restart** button will appear so you can quickly try again without refreshing the page.

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,6 @@
 import {
   spawnZombie,
+  moveZombie,
   moveTowards,
   isColliding,
   generateWalls,
@@ -58,19 +59,17 @@ function update() {
   }
 
   if (spawnTimer <= 0) {
-    zombies.push(spawnZombie(canvas.width, canvas.height));
+    zombies.push(spawnZombie(canvas.width, canvas.height, walls));
     spawnTimer = 60;
   } else {
     spawnTimer--;
   }
 
   zombies.forEach((z) => {
-    const zx = z.x;
-    const zy = z.y;
-    moveTowards(z, player, 1);
+    moveZombie(z, player, walls, 1, canvas.width, canvas.height);
     if (walls.some((w) => circleRectColliding(z, w, 10))) {
-      z.x = zx;
-      z.y = zy;
+      // fallback in case of pathfinding error
+      moveTowards(z, player, 1);
     }
     if (isColliding(z, player, 10)) {
       gameOver = true;

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -6,6 +6,10 @@ import {
   generateWalls,
   circleRectColliding,
   SEGMENT_SIZE,
+  spawnZombie,
+  findPath,
+  hasLineOfSight,
+  moveZombie,
 } from "../src/game_logic.js";
 
 test("moveTowards moves entity toward target", () => {
@@ -40,4 +44,42 @@ test("circleRectColliding detects intersection", () => {
   assert.strictEqual(circleRectColliding(circle, rect, 10), true);
   const far = { x: 10, y: 10 };
   assert.strictEqual(circleRectColliding(far, rect, 10), false);
+});
+
+test("spawnZombie avoids walls", () => {
+  const wall = { x: 40, y: 40, size: SEGMENT_SIZE };
+  for (let i = 0; i < 20; i++) {
+    const z = spawnZombie(80, 80, [wall]);
+    assert.strictEqual(circleRectColliding(z, wall, 10), false);
+  }
+});
+
+test("findPath navigates around walls", () => {
+  const walls = [{ x: 40, y: 0, size: SEGMENT_SIZE }];
+  const start = { x: 10, y: 10 };
+  const end = { x: 90, y: 50 };
+  const path = findPath(start, end, walls, 120, 80);
+  assert(path.length > 0);
+  const blocked = new Set(
+    walls.map((w) => `${w.x / SEGMENT_SIZE},${w.y / SEGMENT_SIZE}`),
+  );
+  path.forEach((c) => {
+    assert.strictEqual(blocked.has(`${c[0]},${c[1]}`), false);
+  });
+});
+
+test("hasLineOfSight detects blockage", () => {
+  const wall = { x: 40, y: 0, size: SEGMENT_SIZE };
+  const start = { x: 10, y: 10 };
+  const end = { x: 90, y: 10 };
+  assert.strictEqual(hasLineOfSight(start, end, [wall], 10), false);
+  assert.strictEqual(hasLineOfSight(start, end, [], 10), true);
+});
+
+test("moveZombie goes straight when unobstructed", () => {
+  const zombie = { x: 0, y: 0 };
+  const player = { x: 30, y: 0 };
+  moveZombie(zombie, player, [], 1, 100, 100);
+  assert(Math.abs(zombie.x - 1) < 1e-6);
+  assert(Math.abs(zombie.y) < 1e-6);
 });


### PR DESCRIPTION
## Summary
- check direct line of sight before pathfinding
- move zombies straight toward the player when unobstructed
- document new behavior
- add unit tests for line-of-sight logic and direct movement

## Testing
- `npm test --silent` in `frontend`
- `pytest -q` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6868b6f3b104832390febfe65e0f203b