### PR TITLE
Add health system and melee weapon

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -14,4 +14,6 @@ npm run dev
 
 The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. Both the player and red zombies spawn around the map, never inside walls. They shamble around slowly until the player wanders within a short distance and is visible. Once triggered, they pursue the player using line‑of‑sight or a short grid-based route when a wall blocks the way. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **Restart** button will appear so you can quickly try again without refreshing the page.
 
-Blue turrets also spawn randomly around the arena. Each turret can shoot a single zombie within range before it needs a short moment to reload. They won't save you from a horde on their own, but luring zombies near them can help thin out the crowd.
+Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
+
+The arena contains a single melee weapon that can be picked up. Press the spacebar to swing the weapon and damage nearby zombies. Turrets no longer spawn automatically; future updates will let players place them manually.

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -1,5 +1,14 @@
+export const ZOMBIE_MAX_HEALTH = 2;
 export function createZombie(x, y) {
-  return { x, y, triggered: false, wanderAngle: 0, wanderTimer: 0 };
+  return {
+    x,
+    y,
+    triggered: false,
+    wanderAngle: 0,
+    wanderTimer: 0,
+    health: ZOMBIE_MAX_HEALTH,
+    attackCooldown: 0,
+  };
 }
 
 export function moveTowards(entity, target, speed) {
@@ -42,6 +51,8 @@ export function spawnPlayer(width, height, walls = []) {
   );
   return player;
 }
+
+export const PLAYER_MAX_HEALTH = 3;
 
 export const SEGMENT_SIZE = 40;
 export const TRIGGER_DISTANCE = 60;
@@ -238,4 +249,33 @@ export function updateTurrets(turrets, zombies) {
       t.cooldown = TURRET_RELOAD;
     }
   });
+}
+
+export function createWeapon(x, y, damage = 1) {
+  return { x, y, damage };
+}
+
+export function spawnWeapon(width, height, walls = []) {
+  let weapon;
+  let attempts = 0;
+  do {
+    weapon = createWeapon(Math.random() * width, Math.random() * height);
+    attempts++;
+  } while (
+    attempts < 20 &&
+    walls.some((w) => circleRectColliding(weapon, w, 10))
+  );
+  return weapon;
+}
+
+export function attackZombies(player, zombies, damage = 1, range = 20) {
+  for (let i = zombies.length - 1; i >= 0; i--) {
+    const z = zombies[i];
+    if (Math.hypot(z.x - player.x, z.y - player.y) <= range) {
+      z.health -= damage;
+      if (z.health <= 0) {
+        zombies.splice(i, 1);
+      }
+    }
+  }
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,8 +7,11 @@ import {
   generateWalls,
   circleRectColliding,
   SEGMENT_SIZE,
-  spawnTurret,
   updateTurrets,
+  spawnWeapon,
+  attackZombies,
+  PLAYER_MAX_HEALTH,
+  ZOMBIE_MAX_HEALTH,
 } from "./game_logic.js";
 
 const canvas = document.getElementById("gameCanvas");
@@ -16,10 +19,18 @@ const ctx = canvas.getContext("2d");
 
 const restartBtn = document.getElementById("restartBtn");
 
-const player = { x: 0, y: 0, speed: 2 };
+const player = {
+  x: 0,
+  y: 0,
+  speed: 2,
+  health: PLAYER_MAX_HEALTH,
+  damageCooldown: 0,
+  weapon: null,
+};
 let zombies = [];
 let turrets = [];
 let walls = [];
+let weapon = null;
 let spawnTimer = 0;
 let gameOver = false;
 const keys = {};
@@ -31,9 +42,10 @@ function resetGame() {
   const spawn = spawnPlayer(canvas.width, canvas.height, walls);
   player.x = spawn.x;
   player.y = spawn.y;
-  for (let i = 0; i < 3; i++) {
-    turrets.push(spawnTurret(canvas.width, canvas.height, walls));
-  }
+  player.health = PLAYER_MAX_HEALTH;
+  player.damageCooldown = 0;
+  player.weapon = null;
+  weapon = spawnWeapon(canvas.width, canvas.height, walls);
   spawnTimer = 0;
   gameOver = false;
   restartBtn.style.display = "none";
@@ -59,12 +71,23 @@ function update() {
   if (keys["arrowleft"] || keys["a"]) player.x -= player.speed;
   if (keys["arrowright"] || keys["d"]) player.x += player.speed;
 
+  if (player.damageCooldown > 0) player.damageCooldown--;
+
   player.x = Math.max(10, Math.min(canvas.width - 10, player.x));
   player.y = Math.max(10, Math.min(canvas.height - 10, player.y));
 
   if (walls.some((w) => circleRectColliding(player, w, 10))) {
     player.x = prevX;
     player.y = prevY;
+  }
+
+  if (weapon && isColliding(player, weapon, 10)) {
+    player.weapon = weapon;
+    weapon = null;
+  }
+
+  if (player.weapon && keys[" "]) {
+    attackZombies(player, zombies, player.weapon.damage, 20);
   }
 
   if (spawnTimer <= 0) {
@@ -80,9 +103,19 @@ function update() {
       // fallback in case of pathfinding error
       moveTowards(z, player, 1);
     }
-    if (isColliding(z, player, 10)) {
-      gameOver = true;
-      restartBtn.style.display = "block";
+    if (z.attackCooldown > 0) z.attackCooldown--;
+    if (
+      isColliding(z, player, 10) &&
+      player.damageCooldown <= 0 &&
+      z.attackCooldown <= 0
+    ) {
+      player.health--;
+      player.damageCooldown = 30;
+      z.attackCooldown = 30;
+      if (player.health <= 0) {
+        gameOver = true;
+        restartBtn.style.display = "block";
+      }
     }
   });
 
@@ -101,12 +134,28 @@ function render() {
   ctx.beginPath();
   ctx.arc(player.x, player.y, 10, 0, Math.PI * 2);
   ctx.fill();
+  ctx.fillStyle = "black";
+  ctx.font = "16px sans-serif";
+  ctx.textAlign = "left";
+  ctx.fillText(`Health: ${player.health}`, 10, 20);
+
+  if (weapon) {
+    ctx.fillStyle = "orange";
+    ctx.beginPath();
+    ctx.arc(weapon.x, weapon.y, 6, 0, Math.PI * 2);
+    ctx.fill();
+  }
 
   ctx.fillStyle = "red";
   zombies.forEach((z) => {
     ctx.beginPath();
     ctx.arc(z.x, z.y, 10, 0, Math.PI * 2);
     ctx.fill();
+    ctx.fillStyle = "black";
+    ctx.fillRect(z.x - 10, z.y - 16, 20, 4);
+    ctx.fillStyle = "lime";
+    ctx.fillRect(z.x - 10, z.y - 16, (z.health / ZOMBIE_MAX_HEALTH) * 20, 4);
+    ctx.fillStyle = "red";
   });
 
   ctx.fillStyle = "blue";

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -17,6 +17,8 @@ import {
   updateTurrets,
   TURRET_RANGE,
   TURRET_RELOAD,
+  attackZombies,
+  ZOMBIE_MAX_HEALTH,
 } from "../src/game_logic.js";
 
 test("moveTowards moves entity toward target", () => {
@@ -143,4 +145,13 @@ test("updateTurrets removes zombie in range", () => {
   updateTurrets([turret], zombies);
   assert.strictEqual(zombies.length, 0);
   assert.strictEqual(turret.cooldown, TURRET_RELOAD);
+});
+
+test("attackZombies damages and removes zombies", () => {
+  const player = { x: 0, y: 0 };
+  const zombies = [{ x: 5, y: 0, health: ZOMBIE_MAX_HEALTH }];
+  attackZombies(player, zombies, 1, 10);
+  assert.strictEqual(zombies[0].health, ZOMBIE_MAX_HEALTH - 1);
+  attackZombies(player, zombies, 1, 10);
+  assert.strictEqual(zombies.length, 0);
 });


### PR DESCRIPTION
## Summary
- disable random turret spawning
- add health for player and zombies
- draw health bars
- implement melee weapon pickup and attack logic
- document health and weapon features
- test zombie attack function

## Testing
- `npm test --prefix frontend`
- `pytest backend`

------
https://chatgpt.com/codex/tasks/task_e_68693a6210888323bb81d03d4c306440