### PR TITLE
Improve melee weapon controls

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -16,4 +16,4 @@ The game runs entirely in the browser. Open `http://localhost:3000` to play. Use
 
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
 
-The arena contains a single melee weapon that can be picked up. Press the spacebar to swing the weapon and damage nearby zombies. Turrets no longer spawn automatically; future updates will let players place them manually.
+The arena contains a single melee weapon that can be picked up. Press the spacebar to swing the weapon. The swing now follows the last direction you moved, creating a short arc in front of the player. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -268,11 +268,42 @@ export function spawnWeapon(width, height, walls = []) {
   return weapon;
 }
 
-export function attackZombies(player, zombies, damage = 1, range = 20) {
+export function attackZombies(
+  player,
+  zombies,
+  damage = 1,
+  range = 30,
+  direction = null,
+  arc = Math.PI / 2,
+  knockback = 0,
+) {
+  const cosHalf = Math.cos(arc / 2);
+  const dirNorm = direction
+    ? (() => {
+        const len = Math.hypot(direction.x, direction.y);
+        if (len === 0) return null;
+        return { x: direction.x / len, y: direction.y / len };
+      })()
+    : null;
+
   for (let i = zombies.length - 1; i >= 0; i--) {
     const z = zombies[i];
-    if (Math.hypot(z.x - player.x, z.y - player.y) <= range) {
+    const dx = z.x - player.x;
+    const dy = z.y - player.y;
+    const dist = Math.hypot(dx, dy);
+    if (dist > range) continue;
+
+    let withinArc = true;
+    if (dirNorm) {
+      withinArc = (dx * dirNorm.x + dy * dirNorm.y) / dist >= cosHalf;
+    }
+
+    if (withinArc) {
       z.health -= damage;
+      if (knockback && dist > 0) {
+        z.x += (dx / dist) * knockback;
+        z.y += (dy / dist) * knockback;
+      }
       if (z.health <= 0) {
         zombies.splice(i, 1);
       }

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -149,9 +149,31 @@ test("updateTurrets removes zombie in range", () => {
 
 test("attackZombies damages and removes zombies", () => {
   const player = { x: 0, y: 0 };
+  const dir = { x: 1, y: 0 };
   const zombies = [{ x: 5, y: 0, health: ZOMBIE_MAX_HEALTH }];
-  attackZombies(player, zombies, 1, 10);
+  attackZombies(player, zombies, 1, 10, dir, Math.PI / 2, 0);
   assert.strictEqual(zombies[0].health, ZOMBIE_MAX_HEALTH - 1);
-  attackZombies(player, zombies, 1, 10);
+  attackZombies(player, zombies, 1, 10, dir, Math.PI / 2, 0);
   assert.strictEqual(zombies.length, 0);
+});
+
+test("attackZombies ignores zombies outside the swing arc", () => {
+  const player = { x: 0, y: 0 };
+  const dir = { x: 1, y: 0 };
+  const zombies = [
+    { x: 5, y: 0, health: 1 },
+    { x: -5, y: 0, health: 1 },
+  ];
+  attackZombies(player, zombies, 1, 10, dir, Math.PI / 2, 0);
+  assert.strictEqual(zombies.length, 1);
+  assert.strictEqual(zombies[0].x < 0, true);
+});
+
+test("attackZombies applies knockback", () => {
+  const player = { x: 0, y: 0 };
+  const dir = { x: 1, y: 0 };
+  const zombies = [{ x: 10, y: 0, health: 2 }];
+  attackZombies(player, zombies, 1, 15, dir, Math.PI / 2, 5);
+  assert(zombies[0].x > 10);
+  assert.strictEqual(zombies[0].health, 1);
 });


### PR DESCRIPTION
## Summary
- orient melee swings based on last movement direction
- add knockback and increased range to melee attacks
- show swing arc while attacking
- document melee updates
- test attack angles and knockback

## Testing
- `npx prettier -w frontend/src/*.js frontend/tests/*.js`
- `black backend/app backend/tests`
- `npm --prefix frontend test`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_686941eb5fbc832384479423e740d4d6