### PR TITLE
Add spawn door and roaming zombies

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -12,7 +12,7 @@ npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. Both the player and red zombies spawn around the map, never inside walls. They shamble around slowly until the player wanders within a short distance and is visible. Once triggered, they pursue the player using line‑of‑sight or a short grid-based route when a wall blocks the way. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **Restart** button will appear so you can quickly try again without refreshing the page.
+The game runs entirely in the browser. Open `http://localhost:3000` to play. Use the arrow keys or WASD to move the green player blob. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **Restart** button will appear so you can quickly try again without refreshing the page.
 
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -12,6 +12,8 @@ import {
   attackZombies,
   PLAYER_MAX_HEALTH,
   ZOMBIE_MAX_HEALTH,
+  createSpawnDoor,
+  spawnZombieAtDoor,
 } from "./game_logic.js";
 
 const canvas = document.getElementById("gameCanvas");
@@ -34,6 +36,7 @@ let turrets = [];
 let walls = [];
 let weapon = null;
 let spawnTimer = 0;
+let spawnDoor = null;
 let gameOver = false;
 const keys = {};
 
@@ -41,6 +44,7 @@ function resetGame() {
   zombies = [];
   turrets = [];
   walls = generateWalls(canvas.width, canvas.height, 4);
+  spawnDoor = createSpawnDoor(canvas.width, canvas.height, walls);
   const spawn = spawnPlayer(canvas.width, canvas.height, walls);
   player.x = spawn.x;
   player.y = spawn.y;
@@ -114,8 +118,8 @@ function update() {
   }
 
   if (spawnTimer <= 0) {
-    zombies.push(spawnZombie(canvas.width, canvas.height, walls));
-    spawnTimer = 60;
+    zombies.push(spawnZombieAtDoor(spawnDoor));
+    spawnTimer = 180 + Math.random() * 120;
   } else {
     spawnTimer--;
   }
@@ -152,6 +156,10 @@ function render() {
   walls.forEach((w) => {
     ctx.fillRect(w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
   });
+  if (spawnDoor) {
+    ctx.fillStyle = "brown";
+    ctx.fillRect(spawnDoor.x - 5, spawnDoor.y - 5, 10, 10);
+  }
 
   ctx.fillStyle = "green";
   ctx.beginPath();

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -19,6 +19,7 @@ import {
   TURRET_RELOAD,
   attackZombies,
   ZOMBIE_MAX_HEALTH,
+  spawnZombieAtDoor,
 } from "../src/game_logic.js";
 
 test("moveTowards moves entity toward target", () => {
@@ -103,12 +104,18 @@ test("zombie triggers when player is near and visible", () => {
 
 test("zombie wanders slowly when player is far", () => {
   const zombie = createZombie(20, 20);
-  zombie.wanderAngle = 0;
-  zombie.wanderTimer = 10;
   const player = { x: 95, y: 20 };
   moveZombie(zombie, player, [], 1, 100, 100);
   assert.strictEqual(zombie.triggered, false);
-  assert(zombie.x > 20 && zombie.x < 21);
+  const dist = Math.hypot(zombie.x - 20, zombie.y - 20);
+  assert(dist > 0 && dist <= 0.3);
+});
+
+test("spawnZombieAtDoor spawns at door location", () => {
+  const door = { x: 0, y: 50 };
+  const z = spawnZombieAtDoor(door);
+  assert.strictEqual(z.x, door.x);
+  assert.strictEqual(z.y, door.y);
 });
 
 test("moveZombie goes straight when unobstructed", () => {


### PR DESCRIPTION
## Summary
- spawn zombies from a single randomly placed door on the arena perimeter
- randomize spawn interval between 3-5 seconds
- let zombies roam toward random destinations when idle
- render the spawn door
- document the new gameplay behaviour
- adjust and add tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869458b6e108323a1a62784bab44dcb