### PR TITLE
Fix UI overlap issues and increase wall count

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -12,10 +12,11 @@ npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the green player blob. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted. Grey wall segments are scattered around the level and block both you and the zombies. If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
+The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the green player blob. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted. Grey wall segments are scattered around the level and block both you and the zombies. The fullscreen layout now uses about twenty segments instead of just four. If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
 
 The canvas now automatically resizes to fill the entire browser window so the action takes up all available space.
 
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
+The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
 
 The arena contains a single melee weapon that can be picked up. Press the spacebar to swing the weapon. The swing now follows the last direction you moved, creating a short arc in front of the player. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,7 +41,9 @@
       <button id="newGameBtn">New Game</button>
     </div>
 
-    <p style="position: absolute; top: 0; left: 0; margin: 8px; color: white">
+    <p
+      style="position: absolute; bottom: 0; left: 0; margin: 8px; color: white"
+    >
       Use WASD or arrow keys to move. Avoid the red zombies!
     </p>
     <script type="module" src="/src/main.js"></script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -61,7 +61,8 @@ function startGame() {
 function resetGame() {
   zombies = [];
   turrets = [];
-  walls = generateWalls(canvas.width, canvas.height, 4);
+  // Use more walls now that the canvas covers the full screen
+  walls = generateWalls(canvas.width, canvas.height, 20);
   spawnDoor = createSpawnDoor(canvas.width, canvas.height, walls);
   const spawn = spawnPlayer(canvas.width, canvas.height, walls);
   player.x = spawn.x;
@@ -234,12 +235,9 @@ function render() {
     ctx.fill();
   });
 
-  if (gameOver) {
-    ctx.fillStyle = "black";
-    ctx.font = "32px sans-serif";
-    ctx.textAlign = "center";
-    ctx.fillText("Game Over", canvas.width / 2, canvas.height / 2);
-  }
+  // The overlay div already shows the Game Over message
+  // and restart button, so nothing is drawn here when
+  // the player loses.
 }
 
 function gameLoop() {


### PR DESCRIPTION
## Summary
- move controls text to the bottom left
- remove duplicate canvas "Game Over" message
- place more walls when resetting the game
- document the updated wall count and control placement

## Testing
- `npm test`
- `black backend`

------
https://chatgpt.com/codex/tasks/task_e_6869c784a2a883239c0f18b11d63742b