### PR TITLE
Add inventory and zombie drop system

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -20,3 +20,11 @@ Players now have a small health pool instead of dying instantly. A "Health" disp
 The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
 
 The arena contains a single melee weapon that can be picked up. Press the spacebar to swing the weapon. The swing now follows the last direction you moved, creating a short arc in front of the player. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
+
+## Inventory System
+
+Press **I** to open the 5x5 inventory grid. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick use. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to use hotbar items.
+
+## Zombie Drops
+
+Zombies may drop **core**, **flesh**, or **teeth** when killed. Walk over a dropped icon to collect it if you have space. Items remain on the ground when the inventory is full and a brief pickup message appears when collecting or using items.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,6 +46,44 @@
     >
       Use WASD or arrow keys to move. Avoid the red zombies!
     </p>
+    <div
+      id="inventory"
+      style="
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: rgba(0, 0, 0, 0.7);
+        padding: 8px;
+        display: none;
+      "
+    >
+      <div
+        id="inventoryGrid"
+        style="display: grid; grid-template-columns: repeat(5, 40px); gap: 4px"
+      ></div>
+    </div>
+    <div
+      id="hotbar"
+      style="
+        position: absolute;
+        bottom: 8px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        gap: 4px;
+      "
+    ></div>
+    <div
+      id="pickupMessage"
+      style="
+        position: absolute;
+        bottom: 40px;
+        left: 50%;
+        transform: translateX(-50%);
+        color: white;
+      "
+    ></div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/frontend/src/inventory.js
+++ b/frontend/src/inventory.js
@@ -1,0 +1,54 @@
+export function createInventory(rows = 5, cols = 5) {
+  const slots = Array.from({ length: rows * cols }, () => ({
+    item: null,
+    count: 0,
+  }));
+  const hotbar = Array.from({ length: 5 }, () => ({ item: null, count: 0 }));
+  return { rows, cols, slots, hotbar };
+}
+
+export function addItem(inv, itemId, amount = 1) {
+  for (const slot of inv.slots) {
+    if (slot.item === itemId && slot.count < 10) {
+      const add = Math.min(amount, 10 - slot.count);
+      slot.count += add;
+      amount -= add;
+      if (amount === 0) return true;
+    }
+  }
+  for (const slot of inv.slots) {
+    if (!slot.item) {
+      const add = Math.min(amount, 10);
+      slot.item = itemId;
+      slot.count = add;
+      amount -= add;
+      if (amount === 0) return true;
+    }
+  }
+  return amount === 0;
+}
+
+export function moveItem(inv, fromIndex, toIndex) {
+  const from = inv.slots[fromIndex];
+  const to = inv.slots[toIndex];
+  inv.slots[toIndex] = from;
+  inv.slots[fromIndex] = to;
+}
+
+export function moveToHotbar(inv, fromIndex, hotbarIndex) {
+  const slot = inv.slots[fromIndex];
+  inv.hotbar[hotbarIndex] = slot;
+  inv.slots[fromIndex] = { item: null, count: 0 };
+}
+
+export function consumeHotbarItem(inv, hotbarIndex) {
+  const slot = inv.hotbar[hotbarIndex];
+  if (!slot.item) return null;
+  slot.count--;
+  const item = slot.item;
+  if (slot.count <= 0) {
+    slot.item = null;
+    slot.count = 0;
+  }
+  return item;
+}

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -18,6 +18,7 @@ import {
   TURRET_RANGE,
   TURRET_RELOAD,
   attackZombies,
+  attackZombiesWithKills,
   ZOMBIE_MAX_HEALTH,
   spawnZombieAtDoor,
 } from "../src/game_logic.js";
@@ -183,4 +184,24 @@ test("attackZombies applies knockback", () => {
   attackZombies(player, zombies, 1, 15, dir, Math.PI / 2, 5);
   assert(zombies[0].x > 10);
   assert.strictEqual(zombies[0].health, 1);
+});
+
+test("attackZombiesWithKills returns dead zombies", () => {
+  const player = { x: 0, y: 0 };
+  const dir = { x: 1, y: 0 };
+  const zombies = [
+    { x: 5, y: 0, health: 1 },
+    { x: -5, y: 0, health: 2 },
+  ];
+  const killed = attackZombiesWithKills(
+    player,
+    zombies,
+    1,
+    10,
+    dir,
+    Math.PI,
+    0,
+  );
+  assert.strictEqual(killed.length, 1);
+  assert.strictEqual(zombies.length, 1);
 });

--- a/frontend/tests/inventory.test.js
+++ b/frontend/tests/inventory.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createInventory,
+  addItem,
+  consumeHotbarItem,
+  moveToHotbar,
+} from "../src/inventory.js";
+
+test("addItem stacks and fills slots", () => {
+  const inv = createInventory(1, 2);
+  assert.strictEqual(addItem(inv, "core", 5), true);
+  assert.strictEqual(inv.slots[0].count, 5);
+  assert.strictEqual(addItem(inv, "core", 6), true);
+  assert.strictEqual(inv.slots[0].count, 10);
+  assert.strictEqual(inv.slots[1].count, 1);
+});
+
+test("consumeHotbarItem reduces count", () => {
+  const inv = createInventory();
+  addItem(inv, "flesh", 1);
+  moveToHotbar(inv, 0, 0);
+  const item = consumeHotbarItem(inv, 0);
+  assert.strictEqual(item, "flesh");
+  assert.strictEqual(inv.hotbar[0].item, null);
+});


### PR DESCRIPTION
## Summary
- implement basic inventory module with hotbar logic
- update zombie AI utilities with kill callbacks
- add world item drops and pickup messages
- extend frontend to render and manage inventory and hotbar
- document the new inventory system and zombie drops
- include tests for inventory logic and new attack function

## Testing
- `npm test` in `frontend`
- `pytest -q` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6869cdc4211c8323929c9b63b65f8c79