### PR TITLE
Implement draggable UI windows and improve hotbar

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -23,7 +23,7 @@ The arena contains a single melee weapon that can be picked up. Press the spaceb
 
 ## Inventory System
 
-Press **I** to open the 5x5 inventory grid. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick use. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to use hotbar items.
+Press **I** to open the 5x5 inventory grid. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick use and now appears on a dark background so it is easy to see. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to use hotbar items. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
 
 ## Zombie Drops
 
@@ -31,4 +31,4 @@ Zombies may drop **core**, **flesh**, or **teeth** when killed. Walk over a drop
 
 ## Crafting
 
-Press **C** while the inventory is open to view available recipes. Only recipes for which you own at least one ingredient are shown. Each entry lists the required materials and how many you currently hold. Clicking a recipe crafts it instantly if you have enough parts. Ingredients are removed from the inventory and the crafted item is placed there as well, or dropped at your feet if no space remains.
+Press **C** to open the crafting menu at any time. Only recipes for which you own at least one ingredient are shown. Each entry lists the required materials and how many you currently hold. Clicking a recipe crafts it instantly if you have enough parts. Ingredients are removed from the inventory and the crafted item is placed there as well, or dropped at your feet if no space remains.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -54,13 +54,37 @@
         left: 50%;
         transform: translate(-50%, -50%);
         background: rgba(0, 0, 0, 0.7);
-        padding: 8px;
+        padding: 0;
         display: none;
       "
     >
       <div
+        style="
+          display: flex;
+          justify-content: space-between;
+          background: rgba(255, 255, 255, 0.1);
+          cursor: move;
+          padding: 4px;
+          color: white;
+        "
+        id="inventoryBar"
+      >
+        <span>Inventory</span>
+        <button
+          id="inventoryClose"
+          style="background: none; border: none; color: white"
+        >
+          x
+        </button>
+      </div>
+      <div
         id="inventoryGrid"
-        style="display: grid; grid-template-columns: repeat(5, 40px); gap: 4px"
+        style="
+          display: grid;
+          grid-template-columns: repeat(5, 40px);
+          gap: 4px;
+          padding: 8px;
+        "
       ></div>
     </div>
     <div
@@ -71,13 +95,31 @@
         left: 50%;
         transform: translate(-50%, -50%);
         background: rgba(0, 0, 0, 0.7);
-        padding: 8px;
+        padding: 0;
         display: none;
         max-width: 300px;
         color: white;
       "
     >
-      <div id="craftingList"></div>
+      <div
+        style="
+          display: flex;
+          justify-content: space-between;
+          background: rgba(255, 255, 255, 0.1);
+          cursor: move;
+          padding: 4px;
+        "
+        id="craftingBar"
+      >
+        <span>Crafting</span>
+        <button
+          id="craftingClose"
+          style="background: none; border: none; color: white"
+        >
+          x
+        </button>
+      </div>
+      <div id="craftingList" style="padding: 8px"></div>
     </div>
     <div
       id="hotbar"
@@ -88,6 +130,10 @@
         transform: translateX(-50%);
         display: flex;
         gap: 4px;
+        background: rgba(0, 0, 0, 0.5);
+        padding: 4px;
+        border: 1px solid white;
+        border-radius: 4px;
       "
     ></div>
     <div


### PR DESCRIPTION
## Summary
- add draggable headers and close buttons for inventory and crafting windows
- make crafting and inventory menus toggle independently
- remember popup window positions
- give the hotbar a dark background so it stands out
- document updated controls

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6869d61676c08323838c07c9c9d0253e