### PR TITLE
Improve inventory UI and weapon handling

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -19,11 +19,12 @@ The canvas now automatically resizes to fill the entire browser window so the ac
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
 The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
 
-The arena contains a single melee weapon that can be picked up. Press the spacebar to swing the weapon. The swing now follows the last direction you moved, creating a short arc in front of the player. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
+The arena contains a baseball bat that can be picked up. When collected it is automatically placed in your inventory and the first hotbar slot. Press the spacebar to swing the bat. The swing now follows the last direction you moved, creating a short arc in front of the player. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
 
 ## Inventory System
 
 Press **I** to open the 5x5 inventory grid. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick use and now appears on a dark background so it is easy to see. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to use hotbar items. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
+Inventory and hotbar slots now display the item icons found in the `assets` folder. If an icon is missing for an item, a `?` will appear instead.
 
 ## Zombie Drops
 

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -297,15 +297,26 @@ export function updateTurrets(turrets, zombies, onKill = () => {}) {
   });
 }
 
-export function createWeapon(x, y, damage = 1) {
-  return { x, y, damage };
+export function createWeapon(x, y, type = "baseball_bat", damage = 1) {
+  return { x, y, type, damage };
 }
 
-export function spawnWeapon(width, height, walls = []) {
+export function spawnWeapon(
+  width,
+  height,
+  walls = [],
+  type = "baseball_bat",
+  damage = 1,
+) {
   let weapon;
   let attempts = 0;
   do {
-    weapon = createWeapon(Math.random() * width, Math.random() * height);
+    weapon = createWeapon(
+      Math.random() * width,
+      Math.random() * height,
+      type,
+      damage,
+    );
     attempts++;
   } while (
     attempts < 20 &&

--- a/frontend/src/inventory.js
+++ b/frontend/src/inventory.js
@@ -41,6 +41,18 @@ export function moveToHotbar(inv, fromIndex, hotbarIndex) {
   inv.slots[fromIndex] = { item: null, count: 0 };
 }
 
+export function swapHotbar(inv, indexA, indexB) {
+  const tmp = inv.hotbar[indexA];
+  inv.hotbar[indexA] = inv.hotbar[indexB];
+  inv.hotbar[indexB] = tmp;
+}
+
+export function moveFromHotbar(inv, hotbarIndex, invIndex) {
+  const slot = inv.hotbar[hotbarIndex];
+  inv.slots[invIndex] = slot;
+  inv.hotbar[hotbarIndex] = { item: null, count: 0 };
+}
+
 export function consumeHotbarItem(inv, hotbarIndex) {
   const slot = inv.hotbar[hotbarIndex];
   if (!slot.item) return null;

--- a/frontend/tests/inventory.test.js
+++ b/frontend/tests/inventory.test.js
@@ -5,6 +5,8 @@ import {
   addItem,
   consumeHotbarItem,
   moveToHotbar,
+  swapHotbar,
+  moveFromHotbar,
   countItem,
   removeItem,
 } from "../src/inventory.js";
@@ -42,4 +44,24 @@ test("removeItem deducts from inventory", () => {
   assert.strictEqual(countItem(inv, "teeth"), 1);
   removeItem(inv, "teeth", 1);
   assert.strictEqual(countItem(inv, "teeth"), 0);
+});
+
+test("swapHotbar exchanges slots", () => {
+  const inv = createInventory();
+  addItem(inv, "core", 1);
+  addItem(inv, "flesh", 1);
+  moveToHotbar(inv, 0, 0);
+  moveToHotbar(inv, 1, 1);
+  swapHotbar(inv, 0, 1);
+  assert.strictEqual(inv.hotbar[0].item, "flesh");
+  assert.strictEqual(inv.hotbar[1].item, "core");
+});
+
+test("moveFromHotbar moves item back to inventory", () => {
+  const inv = createInventory();
+  addItem(inv, "core", 1);
+  moveToHotbar(inv, 0, 0);
+  moveFromHotbar(inv, 0, 1);
+  assert.strictEqual(inv.hotbar[0].item, null);
+  assert.strictEqual(inv.slots[1].item, "core");
 });


### PR DESCRIPTION
## Summary
- ensure draggable windows remember their last position
- display item icons in inventory and hotbar
- add utility functions for hotbar management
- update gameplay to use a baseball bat pickup that goes to the hotbar
- document new behaviour and add tests

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869d9ff08748323803c192ae6b193a7