### PR TITLE
Improve crafting and hotbar logic

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -19,11 +19,11 @@ The canvas now automatically resizes to fill the entire browser window so the ac
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
 The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
 
-The arena contains a baseball bat that can be picked up. When collected it is automatically placed in your inventory and the first hotbar slot. Press the spacebar to swing the bat. The swing now follows the last direction you moved, creating a short arc in front of the player. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
+The arena contains a baseball bat that can be picked up. When collected it is automatically placed in your inventory and the first hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the spacebar to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
 
 ## Inventory System
 
-Press **I** to open the 5x5 inventory grid. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick use and now appears on a dark background so it is easy to see. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to use hotbar items. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
+Press **I** to open the 5x5 inventory grid. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
 Inventory and hotbar slots now display the item icons found in the `assets` folder. If an icon is missing for an item, a `?` will appear instead.
 
 ## Zombie Drops
@@ -32,4 +32,4 @@ Zombies may drop **core**, **flesh**, or **teeth** when killed. Walk over a drop
 
 ## Crafting
 
-Press **C** to open the crafting menu at any time. Only recipes for which you own at least one ingredient are shown. Each entry lists the required materials and how many you currently hold. Clicking a recipe crafts it instantly if you have enough parts. Ingredients are removed from the inventory and the crafted item is placed there as well, or dropped at your feet if no space remains.
+Press **C** to open the crafting menu at any time. Only recipes for which you own at least one ingredient are shown. Each entry now displays an icon of the resulting item along with icons for all required materials and their counts. Clicking a recipe crafts it instantly if you have enough parts. Ingredients are removed from the inventory and the crafted item is placed there as well, or dropped at your feet if no space remains.

--- a/frontend/src/inventory.js
+++ b/frontend/src/inventory.js
@@ -4,7 +4,7 @@ export function createInventory(rows = 5, cols = 5) {
     count: 0,
   }));
   const hotbar = Array.from({ length: 5 }, () => ({ item: null, count: 0 }));
-  return { rows, cols, slots, hotbar };
+  return { rows, cols, slots, hotbar, active: 0 };
 }
 
 export function addItem(inv, itemId, amount = 1) {
@@ -86,4 +86,12 @@ export function removeItem(inv, itemId, amount = 1) {
     }
   }
   return amount === 0;
+}
+
+export function setActiveHotbar(inv, index) {
+  inv.active = Math.max(0, Math.min(inv.hotbar.length - 1, index));
+}
+
+export function getActiveHotbarItem(inv) {
+  return inv.hotbar[inv.active];
 }

--- a/frontend/tests/inventory.test.js
+++ b/frontend/tests/inventory.test.js
@@ -9,6 +9,8 @@ import {
   moveFromHotbar,
   countItem,
   removeItem,
+  setActiveHotbar,
+  getActiveHotbarItem,
 } from "../src/inventory.js";
 
 test("addItem stacks and fills slots", () => {
@@ -64,4 +66,14 @@ test("moveFromHotbar moves item back to inventory", () => {
   moveFromHotbar(inv, 0, 1);
   assert.strictEqual(inv.hotbar[0].item, null);
   assert.strictEqual(inv.slots[1].item, "core");
+});
+
+test("setActiveHotbar updates active slot", () => {
+  const inv = createInventory();
+  addItem(inv, "core", 1);
+  moveToHotbar(inv, 0, 2);
+  setActiveHotbar(inv, 2);
+  const slot = getActiveHotbarItem(inv);
+  assert.strictEqual(inv.active, 2);
+  assert.strictEqual(slot.item, "core");
 });


### PR DESCRIPTION
## Summary
- show item icons in crafting menu
- track active hotbar slot in inventory
- use baseball bat only from active slot
- document hotbar changes and crafting icons
- test new hotbar helpers

## Testing
- `npm test --prefix frontend`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6869df579f8883238b7eff3f32dd5b8f