### PR TITLE
Add medkit heal and sprite rendering

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -12,7 +12,7 @@ npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the green player blob. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted. Grey wall segments are scattered around the level and block both you and the zombies. The fullscreen layout now uses about twenty segments instead of just four. If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
+The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted. Grey wall segments are scattered around the level and block both you and the zombies. The fullscreen layout now uses about twenty segments instead of just four. If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
 
 The canvas now automatically resizes to fill the entire browser window so the action takes up all available space.
 
@@ -37,3 +37,5 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 ## Containers
 
 Brown containers are scattered around the arena. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the container opens. Each container can hold a single Medkit with a 64% chance. If found and your inventory has space, the Medkit is automatically added. Otherwise, the container keeps the item and displays "Inventory Full". Empty containers show "Container Empty" and cannot be looted again. Opened containers appear faded so you know they have been searched.
+
+Using a Medkit from the hotbar restores up to 3 health without exceeding your maximum.

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -3,6 +3,7 @@ export function createZombie(x, y) {
   return {
     x,
     y,
+    facing: { x: 0, y: 1 },
     triggered: false,
     // Used by passive roaming logic
     dest: null,
@@ -21,6 +22,10 @@ export function moveTowards(entity, target, speed) {
   if (dist === 0) return;
   entity.x += (dx / dist) * speed;
   entity.y += (dy / dist) * speed;
+  if (entity.facing) {
+    entity.facing.x = dx / dist;
+    entity.facing.y = dy / dist;
+  }
 }
 
 export function isColliding(a, b, radius) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -65,6 +65,20 @@ const ITEM_ICONS = {
   medkit: "assets/medkit.png",
 };
 
+const playerSprite = new Image();
+playerSprite.src = "assets/sprite_player.png";
+const zombieSprite = new Image();
+zombieSprite.src = "assets/sprite_zombie.png";
+
+function drawSprite(ctx, img, x, y, facing, size = 32) {
+  const angle = Math.atan2(facing.y, facing.x) - Math.PI / 2;
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.rotate(angle);
+  ctx.drawImage(img, -size / 2, -size / 2, size, size);
+  ctx.restore();
+}
+
 const player = {
   x: 0,
   y: 0,
@@ -484,6 +498,10 @@ window.addEventListener("keydown", (e) => {
     if (slot.item && slot.item !== "baseball_bat") {
       const used = consumeHotbarItem(inventory, idx);
       if (used) {
+        if (used === "medkit") {
+          player.health = Math.min(PLAYER_MAX_HEALTH, player.health + 3);
+          renderInventory();
+        }
         pickupMsg.textContent = `Used ${used}`;
         pickupMessageTimer = 60;
       }
@@ -678,10 +696,7 @@ function render() {
     ctx.fillRect(spawnDoor.x - 5, spawnDoor.y - 5, 10, 10);
   }
 
-  ctx.fillStyle = "green";
-  ctx.beginPath();
-  ctx.arc(player.x, player.y, 10, 0, Math.PI * 2);
-  ctx.fill();
+  drawSprite(ctx, playerSprite, player.x, player.y, player.facing);
 
   if (player.swingTimer > 0) {
     ctx.strokeStyle = "orange";
@@ -711,16 +726,12 @@ function render() {
     ctx.fill();
   });
 
-  ctx.fillStyle = "red";
   zombies.forEach((z) => {
-    ctx.beginPath();
-    ctx.arc(z.x, z.y, 10, 0, Math.PI * 2);
-    ctx.fill();
+    drawSprite(ctx, zombieSprite, z.x, z.y, z.facing);
     ctx.fillStyle = "black";
     ctx.fillRect(z.x - 10, z.y - 16, 20, 4);
     ctx.fillStyle = "lime";
     ctx.fillRect(z.x - 10, z.y - 16, (z.health / ZOMBIE_MAX_HEALTH) * 20, 4);
-    ctx.fillStyle = "red";
   });
 
   ctx.fillStyle = "blue";


### PR DESCRIPTION
## Summary
- rotate sprites to face movement
- load player & zombie sprites
- heal for up to 3 HP when using a medkit
- document the new sprites and medkit usage

## Testing
- `npm test --prefix frontend`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6869e5e363f88323b9488dd2b58fa1f7