### PR TITLE
Improve item visuals

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -19,7 +19,7 @@ The canvas now automatically resizes to fill the entire browser window so the ac
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
 The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
 
-The arena contains a baseball bat that can be picked up. When collected it is automatically placed in your inventory and the first hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the spacebar to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
+The arena contains a baseball bat that starts on the ground. It now appears using its bat icon rather than an orange dot. When collected it is automatically placed in your inventory and the first hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the spacebar to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
 
 ## Inventory System
 
@@ -36,6 +36,6 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 
 ## Containers
 
-Brown containers are scattered around the arena. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the container opens. Each container can hold a single Medkit with a 64% chance. If found and your inventory has space, the Medkit is automatically added. Otherwise, the container keeps the item and displays "Inventory Full". Empty containers show "Container Empty" and cannot be looted again. Opened containers appear faded so you know they have been searched.
+Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box can hold a single Medkit with a 64% chance. If found and your inventory has space, the Medkit is automatically added. Otherwise, the box keeps the item and displays "Inventory Full". Empty boxes show "Container Empty" and cannot be looted again. Opened boxes appear faded so you know they have been searched.
 
 Using a Medkit from the hotbar restores up to 3 health without exceeding your maximum.

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -71,7 +71,7 @@ export function randomOpenPosition(width, height, walls = []) {
 }
 
 export function createContainer(x, y) {
-  return { x, y, opened: false, item: null };
+  return { x, y, opened: false, item: null, type: "cardboard_box" };
 }
 
 export function spawnContainers(width, height, walls = [], count = 3) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -65,6 +65,17 @@ const ITEM_ICONS = {
   medkit: "assets/medkit.png",
 };
 
+// Preload image objects for item icons so they can be drawn on the canvas
+const ITEM_IMAGES = {};
+for (const [id, path] of Object.entries(ITEM_ICONS)) {
+  const img = new Image();
+  img.src = path;
+  ITEM_IMAGES[id] = img;
+}
+
+const cardboardBoxImg = new Image();
+cardboardBoxImg.src = "assets/cardboard_box.png";
+
 const playerSprite = new Image();
 playerSprite.src = "assets/sprite_player.png";
 const zombieSprite = new Image();
@@ -685,10 +696,9 @@ function render() {
   walls.forEach((w) => {
     ctx.fillRect(w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
   });
-  ctx.fillStyle = "brown";
   containers.forEach((c) => {
     ctx.globalAlpha = c.opened ? 0.5 : 1;
-    ctx.fillRect(c.x - 10, c.y - 10, 20, 20);
+    ctx.drawImage(cardboardBoxImg, c.x - 10, c.y - 10, 20, 20);
     ctx.globalAlpha = 1;
   });
   if (spawnDoor) {
@@ -713,10 +723,15 @@ function render() {
   ctx.fillText(`Health: ${player.health}`, 10, 20);
 
   if (weapon) {
-    ctx.fillStyle = "orange";
-    ctx.beginPath();
-    ctx.arc(weapon.x, weapon.y, 6, 0, Math.PI * 2);
-    ctx.fill();
+    const img = ITEM_IMAGES[weapon.type];
+    if (img) {
+      ctx.drawImage(img, weapon.x - 8, weapon.y - 8, 16, 16);
+    } else {
+      ctx.fillStyle = "orange";
+      ctx.beginPath();
+      ctx.arc(weapon.x, weapon.y, 6, 0, Math.PI * 2);
+      ctx.fill();
+    }
   }
 
   ctx.fillStyle = "yellow";

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -214,5 +214,6 @@ test("spawnContainers places non-colliding containers", () => {
   assert.strictEqual(containers.length, 3);
   containers.forEach((c) => {
     assert.strictEqual(circleRectColliding(c, walls[0], 10), false);
+    assert.strictEqual(c.type, "cardboard_box");
   });
 });


### PR DESCRIPTION
## Summary
- show baseball bat icon on the ground
- rename looted containers to cardboard boxes and draw icon
- document the new icons
- test container type value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869e8fe9c688323b3132f2e801c03d2