### PR TITLE
Fix inventory key handling and zombie collision

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -12,7 +12,7 @@ npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted. Grey wall segments are scattered around the level and block both you and the zombies. The fullscreen layout now uses about twenty segments instead of just four. If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
+The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted. Grey wall segments are scattered around the level and block both you and the zombies. Zombies now reliably stop when they hit these walls instead of occasionally slipping through them. The fullscreen layout now uses about twenty segments instead of just four. If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
 
 The canvas now automatically resizes to fill the entire browser window so the action takes up all available space.
 
@@ -23,7 +23,7 @@ The arena contains a baseball bat that starts on the ground. It now appears usin
 
 ## Inventory System
 
-Press **I** to open the 5x5 inventory grid. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
+Press **I** (or **E**) to open the 5x5 inventory grid. Keys are matched case-insensitively so holding Shift won't prevent the menus from toggling. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
 Inventory and hotbar slots now display the item icons found in the `assets` folder. If an icon is missing for an item, a `?` will appear instead.
 
 ## Zombie Drops

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -279,14 +279,26 @@ export function moveZombie(zombie, player, walls, speed, width, height) {
   }
 
   if (hasLineOfSight(zombie, player, walls, 10)) {
+    const prevX = zombie.x;
+    const prevY = zombie.y;
     moveTowards(zombie, player, speed);
+    if (walls.some((w) => circleRectColliding(zombie, w, 10))) {
+      zombie.x = prevX;
+      zombie.y = prevY;
+    }
     return;
   }
 
   const path = findPath(zombie, player, walls, width, height);
   if (path.length < 2) {
     // Fallback to direct movement when no path is found
+    const prevX = zombie.x;
+    const prevY = zombie.y;
     moveTowards(zombie, player, speed);
+    if (walls.some((w) => circleRectColliding(zombie, w, 10))) {
+      zombie.x = prevX;
+      zombie.y = prevY;
+    }
     return;
   }
 
@@ -295,7 +307,13 @@ export function moveZombie(zombie, player, walls, speed, width, height) {
     x: nx * SEGMENT_SIZE + SEGMENT_SIZE / 2,
     y: ny * SEGMENT_SIZE + SEGMENT_SIZE / 2,
   };
+  const prevX = zombie.x;
+  const prevY = zombie.y;
   moveTowards(zombie, target, speed);
+  if (walls.some((w) => circleRectColliding(zombie, w, 10))) {
+    zombie.x = prevX;
+    zombie.y = prevY;
+  }
 }
 
 export function updateTurrets(turrets, zombies, onKill = () => {}) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -495,15 +495,16 @@ makeDraggable(
 );
 
 window.addEventListener("keydown", (e) => {
-  keys[e.key.toLowerCase()] = true;
-  if (e.key === "i" || e.key === "e") {
+  const key = e.key.toLowerCase();
+  keys[key] = true;
+  if (key === "i" || key === "e") {
     toggleInventory(!inventoryOpen);
   }
-  if (e.key.toLowerCase() === "c") {
+  if (key === "c") {
     toggleCrafting(!craftingOpen);
   }
-  if (/^[1-5]$/.test(e.key)) {
-    const idx = parseInt(e.key) - 1;
+  if (/^[1-5]$/.test(key)) {
+    const idx = parseInt(key) - 1;
     setActiveHotbar(inventory, idx);
     const slot = inventory.hotbar[idx];
     if (slot.item && slot.item !== "baseball_bat") {
@@ -661,10 +662,6 @@ function update() {
 
   zombies.forEach((z) => {
     moveZombie(z, player, walls, 1, canvas.width, canvas.height);
-    if (walls.some((w) => circleRectColliding(z, w, 10))) {
-      // fallback in case of pathfinding error
-      moveTowards(z, player, 1);
-    }
     if (z.attackCooldown > 0) z.attackCooldown--;
     if (
       isColliding(z, player, 10) &&

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -217,3 +217,13 @@ test("spawnContainers places non-colliding containers", () => {
     assert.strictEqual(c.type, "cardboard_box");
   });
 });
+
+test("moveZombie does not move through walls when path fails", () => {
+  const wall = { x: 40, y: 40, size: SEGMENT_SIZE };
+  const zombie = createZombie(30, 60);
+  zombie.triggered = true;
+  // Player is inside the wall so no path exists
+  const player = { x: 60, y: 60 };
+  moveZombie(zombie, player, [wall], 1, 120, 120);
+  assert.strictEqual(circleRectColliding(zombie, wall, 10), false);
+});


### PR DESCRIPTION
## Summary
- fix inventory toggle listener to accept uppercase keys
- ensure zombies revert movement when colliding with walls
- update zombie collision tests
- document case-insensitive inventory toggle
- note improved zombie wall collisions

## Testing
- `npm test --prefix frontend`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6869f0b71afc83239bc2d0a2482b00f3