### PR TITLE
Add Fire Zombie variant

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -39,3 +39,7 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box can hold a single Medkit with a 64% chance. If found and your inventory has space, the Medkit is automatically added. Otherwise, the box keeps the item and displays "Inventory Full". Empty boxes show "Container Empty" and cannot be looted again. Opened boxes appear faded so you know they have been searched.
 
 Using a Medkit from the hotbar restores up to 3 health without exceeding your maximum.
+
+## Fire Zombies
+
+Some zombies emerge imbued with flame. These **Fire Zombies** appear with a red tint and glow effect so they are easy to spot. They behave like normal zombies but spawn with a 20% probability whenever a new zombie enters through the door.

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -1,5 +1,7 @@
 export const ZOMBIE_MAX_HEALTH = 2;
-export function createZombie(x, y) {
+export const FIRE_ZOMBIE_CHANCE = 0.2;
+
+export function createZombie(x, y, variant = "normal") {
   return {
     x,
     y,
@@ -12,7 +14,12 @@ export function createZombie(x, y) {
     wanderTimer: 0,
     health: ZOMBIE_MAX_HEALTH,
     attackCooldown: 0,
+    variant,
   };
+}
+
+export function createFireZombie(x, y) {
+  return createZombie(x, y, "fire");
 }
 
 export function moveTowards(entity, target, speed) {
@@ -38,7 +45,12 @@ export function spawnZombie(width, height, walls = []) {
   let zombie;
   let attempts = 0;
   do {
-    zombie = createZombie(Math.random() * width, Math.random() * height);
+    const variant = Math.random() < FIRE_ZOMBIE_CHANCE ? "fire" : "normal";
+    zombie = createZombie(
+      Math.random() * width,
+      Math.random() * height,
+      variant,
+    );
     attempts++;
   } while (
     attempts < 20 &&
@@ -101,7 +113,8 @@ export function createSpawnDoor(width, height, walls = []) {
 }
 
 export function spawnZombieAtDoor(door) {
-  return createZombie(door.x, door.y);
+  const variant = Math.random() < FIRE_ZOMBIE_CHANCE ? "fire" : "normal";
+  return createZombie(door.x, door.y, variant);
 }
 
 export const PLAYER_MAX_HEALTH = 10;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -80,6 +80,8 @@ const playerSprite = new Image();
 playerSprite.src = "assets/sprite_player.png";
 const zombieSprite = new Image();
 zombieSprite.src = "assets/sprite_zombie.png";
+const fireZombieSprite = new Image();
+fireZombieSprite.src = "assets/sprite_fire_zombie.png";
 
 function drawSprite(ctx, img, x, y, facing, size = 32) {
   const angle = Math.atan2(facing.y, facing.x) - Math.PI / 2;
@@ -739,7 +741,17 @@ function render() {
   });
 
   zombies.forEach((z) => {
-    drawSprite(ctx, zombieSprite, z.x, z.y, z.facing);
+    if (z.variant === "fire") {
+      const grad = ctx.createRadialGradient(z.x, z.y, 0, z.x, z.y, 20);
+      grad.addColorStop(0, "rgba(255,100,0,0.8)");
+      grad.addColorStop(1, "rgba(255,0,0,0)");
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(z.x, z.y, 20, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    const img = z.variant === "fire" ? fireZombieSprite : zombieSprite;
+    drawSprite(ctx, img, z.x, z.y, z.facing);
     ctx.fillStyle = "black";
     ctx.fillRect(z.x - 10, z.y - 16, 20, 4);
     ctx.fillStyle = "lime";

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -121,6 +121,18 @@ test("spawnZombieAtDoor spawns at door location", () => {
   assert.strictEqual(z.y, door.y);
 });
 
+test("spawnZombieAtDoor uses random chance for fire variant", () => {
+  const door = { x: 10, y: 10 };
+  const originalRandom = Math.random;
+  Math.random = () => 0.1; // below threshold
+  const fire = spawnZombieAtDoor(door);
+  Math.random = () => 0.9; // above threshold
+  const normal = spawnZombieAtDoor(door);
+  Math.random = originalRandom;
+  assert.strictEqual(fire.variant, "fire");
+  assert.strictEqual(normal.variant, "normal");
+});
+
 test("moveZombie goes straight when unobstructed", () => {
   const zombie = createZombie(0, 0);
   zombie.triggered = true;


### PR DESCRIPTION
## Summary
- support zombie variants with new `variant` field
- implement `FIRE_ZOMBIE_CHANCE` with 20% probability
- display fire zombies using a fire sprite and glow effect
- document the new variant
- test variant selection logic

## Testing
- `npx --yes prettier -w frontend/src/game_logic.js frontend/src/main.js frontend/tests/game_logic.test.js`
- `npm test --prefix frontend`
- `black backend/app`

------
https://chatgpt.com/codex/tasks/task_e_6869f90e3df0832394d293b4dcb8a709