### PR TITLE
Implement Fireball ability with projectiles

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -48,4 +48,8 @@ Some zombies emerge imbued with flame. These **Fire Zombies** appear with a red 
 
 Collecting Fire Cores unlocks a new recipe:
 
-* **Fire Mutation Serum** - Combine three Fire Cores to craft. Right-click the serum in your inventory or hotbar to inject it and permanently gain the Fireball ability (ability implementation coming later).
+- **Fire Mutation Serum** - Combine three Fire Cores to craft. Right-click the serum in your inventory or hotbar to inject it and permanently gain the Fireball ability.
+
+## Fireball Ability
+
+Injecting the serum adds a new _Fireball_ entry to your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Spacebar** to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears.

--- a/frontend/src/spells.js
+++ b/frontend/src/spells.js
@@ -1,0 +1,41 @@
+export const FIREBALL_SPEED = 3;
+export const FIREBALL_RANGE = 8 * 40; // 8 tiles assuming SEGMENT_SIZE=40
+export const FIREBALL_DAMAGE = 3;
+
+import { circleRectColliding, isColliding } from "./game_logic.js";
+
+export function createFireball(x, y, direction) {
+  const len = Math.hypot(direction.x, direction.y);
+  if (len === 0) return null;
+  const vx = (direction.x / len) * FIREBALL_SPEED;
+  const vy = (direction.y / len) * FIREBALL_SPEED;
+  return { x, y, vx, vy, traveled: 0 };
+}
+
+export function updateFireballs(fireballs, zombies, walls, onKill = () => {}) {
+  for (let i = fireballs.length - 1; i >= 0; i--) {
+    const fb = fireballs[i];
+    fb.x += fb.vx;
+    fb.y += fb.vy;
+    fb.traveled += Math.hypot(fb.vx, fb.vy);
+    let remove = fb.traveled >= FIREBALL_RANGE;
+    if (!remove && walls.some((w) => circleRectColliding(fb, w, 4))) {
+      remove = true;
+    }
+    if (!remove) {
+      for (let j = zombies.length - 1; j >= 0; j--) {
+        const z = zombies[j];
+        if (isColliding(fb, z, 4)) {
+          z.health -= FIREBALL_DAMAGE;
+          if (z.health <= 0) {
+            zombies.splice(j, 1);
+            onKill(z);
+          }
+          remove = true;
+          break;
+        }
+      }
+    }
+    if (remove) fireballs.splice(i, 1);
+  }
+}

--- a/frontend/tests/spells.test.js
+++ b/frontend/tests/spells.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createFireball, updateFireballs } from "../src/spells.js";
+
+// mocks for game_logic helpers
+import { circleRectColliding, isColliding } from "../src/game_logic.js";
+
+test("createFireball normalizes direction", () => {
+  const fb = createFireball(0, 0, { x: 3, y: 4 });
+  assert(Math.abs(fb.vx - 1.8) < 1e-6);
+  assert(Math.abs(fb.vy - 2.4) < 1e-6);
+});
+
+test("updateFireballs moves and hits zombie", () => {
+  const fireballs = [createFireball(0, 0, { x: 1, y: 0 })];
+  const zombies = [{ x: 5, y: 0, health: 3 }];
+  for (let i = 0; i < 10 && fireballs.length > 0; i++) {
+    updateFireballs(fireballs, zombies, []);
+  }
+  assert.strictEqual(fireballs.length, 0);
+  assert.strictEqual(zombies.length === 0 || zombies[0].health < 3, true);
+});


### PR DESCRIPTION
## Summary
- add fireball projectile helpers
- enable ability unlocking and use in hotbar
- consume fire cores when casting fireball
- display fireballs and update docs
- test new fireball logic

## Testing
- `npx prettier -w frontend/src/spells.js frontend/tests/spells.test.js frontend/src/main.js docs/zombie_game.md`
- `black backend`
- `npm test --silent --prefix frontend`
- `pytest -q backend`


------
https://chatgpt.com/codex/tasks/task_e_686a02bd36408323b1ae03d8bca39416