### PR TITLE
Fix fireball persistence between runs

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -48,8 +48,9 @@ Some zombies emerge imbued with flame. These **Fire Zombies** appear with a red 
 
 Collecting Fire Cores unlocks a new recipe:
 
-- **Fire Mutation Serum** - Combine three Fire Cores to craft. Right-click the serum in your inventory or hotbar to inject it and permanently gain the Fireball ability.
+- **Fire Mutation Serum** - Combine three Fire Cores to craft. Right-click the serum in your inventory or hotbar to inject it and gain the Fireball ability for the rest of the current game.
 
 ## Fireball Ability
 
 Injecting the serum adds a new _Fireball_ entry to your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Spacebar** to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears.
+Starting a new game resets this ability so you must craft the serum again in future runs.

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17,6 +17,7 @@ import {
   spawnZombieAtDoor,
   spawnContainers,
 } from "./game_logic.js";
+import { createPlayer, resetPlayerForNewGame } from "./player.js";
 import {
   createInventory,
   addItem,
@@ -97,17 +98,7 @@ function drawSprite(ctx, img, x, y, facing, size = 32) {
   ctx.restore();
 }
 
-const player = {
-  x: 0,
-  y: 0,
-  speed: 2,
-  health: PLAYER_MAX_HEALTH,
-  damageCooldown: 0,
-  weapon: null,
-  facing: { x: 1, y: 0 },
-  swingTimer: 0,
-  abilities: { fireball: false },
-};
+const player = createPlayer(PLAYER_MAX_HEALTH);
 let zombies = [];
 let turrets = [];
 let walls = [];
@@ -481,9 +472,7 @@ function resetGame() {
   const spawn = spawnPlayer(canvas.width, canvas.height, walls);
   player.x = spawn.x;
   player.y = spawn.y;
-  player.health = PLAYER_MAX_HEALTH;
-  player.damageCooldown = 0;
-  player.weapon = null;
+  resetPlayerForNewGame(player, PLAYER_MAX_HEALTH);
   weapon = spawnWeapon(canvas.width, canvas.height, walls, "baseball_bat", 1);
   spawnTimer = 0;
   containers = spawnContainers(

--- a/frontend/src/player.js
+++ b/frontend/src/player.js
@@ -1,0 +1,21 @@
+export function createPlayer(PLAYER_MAX_HEALTH) {
+  return {
+    x: 0,
+    y: 0,
+    speed: 2,
+    health: PLAYER_MAX_HEALTH,
+    damageCooldown: 0,
+    weapon: null,
+    facing: { x: 1, y: 0 },
+    swingTimer: 0,
+    abilities: { fireball: false },
+  };
+}
+
+export function resetPlayerForNewGame(player, PLAYER_MAX_HEALTH) {
+  player.health = PLAYER_MAX_HEALTH;
+  player.damageCooldown = 0;
+  player.weapon = null;
+  player.swingTimer = 0;
+  player.abilities.fireball = false;
+}

--- a/frontend/tests/player.test.js
+++ b/frontend/tests/player.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPlayer, resetPlayerForNewGame } from "../src/player.js";
+import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
+
+test("resetPlayerForNewGame clears abilities and restores health", () => {
+  const player = createPlayer(PLAYER_MAX_HEALTH);
+  player.abilities.fireball = true;
+  player.health = 1;
+  player.weapon = { type: "bat" };
+  resetPlayerForNewGame(player, PLAYER_MAX_HEALTH);
+  assert.strictEqual(player.abilities.fireball, false);
+  assert.strictEqual(player.health, PLAYER_MAX_HEALTH);
+  assert.strictEqual(player.weapon, null);
+});


### PR DESCRIPTION
## Summary
- add a small `player` utility module for creating and resetting player state
- reset player abilities when starting a new game so fireball isn't permanent
- document that the mutation serum only lasts for the current run
- test the new player reset helper

## Testing
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_686a96826a1883239dd9ef76ef8794f4