### PR TITLE
Improve inventory item stacking

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -19,11 +19,11 @@ The canvas now automatically resizes to fill the entire browser window so the ac
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
 The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
 
-The arena contains a baseball bat that starts on the ground. It now appears using its bat icon rather than an orange dot. When collected it is automatically placed in your inventory and the first hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the spacebar to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
+The arena contains a baseball bat that starts on the ground. It now appears using its bat icon rather than an orange dot. When collected it automatically occupies the first open hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the spacebar to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
 
 ## Inventory System
 
-Press **I** (or **E**) to open the 5x5 inventory grid. Keys are matched case-insensitively so holding Shift won't prevent the menus from toggling. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
+Press **I** (or **E**) to open the 5x5 inventory grid. Keys are matched case-insensitively so holding Shift won't prevent the menus from toggling. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Newly picked up items fill the first empty hotbar slot before using inventory space. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
 Inventory and hotbar slots now display the item icons found in the `assets` folder. If an icon is missing for an item, a `?` will appear instead.
 
 ## Zombie Drops
@@ -38,7 +38,7 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 
 ## Containers
 
-Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box can hold a single Medkit with a 64% chance. If found and your inventory has space, the Medkit is automatically added. Otherwise, the box keeps the item and displays "Inventory Full". Empty boxes show "Container Empty" and cannot be looted again. Opened boxes appear faded so you know they have been searched.
+Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box can hold a single Medkit with a 64% chance. If found and there is room in your hotbar or inventory, the Medkit is automatically added. Otherwise, the box keeps the item and displays "Inventory Full". Empty boxes show "Container Empty" and cannot be looted again. Opened boxes appear faded so you know they have been searched.
 
 Using a Medkit from the hotbar restores up to 3 health without exceeding your maximum.
 

--- a/frontend/src/inventory.js
+++ b/frontend/src/inventory.js
@@ -8,7 +8,8 @@ export function createInventory(rows = 5, cols = 5) {
 }
 
 export function addItem(inv, itemId, amount = 1) {
-  for (const slot of inv.slots) {
+  // First fill existing stacks across hotbar and inventory
+  for (const slot of [...inv.hotbar, ...inv.slots]) {
     if (slot.item === itemId && slot.count < 10) {
       const add = Math.min(amount, 10 - slot.count);
       slot.count += add;
@@ -16,6 +17,19 @@ export function addItem(inv, itemId, amount = 1) {
       if (amount === 0) return true;
     }
   }
+
+  // Next place new stacks into open hotbar slots
+  for (const slot of inv.hotbar) {
+    if (!slot.item) {
+      const add = Math.min(amount, 10);
+      slot.item = itemId;
+      slot.count = add;
+      amount -= add;
+      if (amount === 0) return true;
+    }
+  }
+
+  // Finally fill empty inventory slots
   for (const slot of inv.slots) {
     if (!slot.item) {
       const add = Math.min(amount, 10);
@@ -25,6 +39,7 @@ export function addItem(inv, itemId, amount = 1) {
       if (amount === 0) return true;
     }
   }
+
   return amount === 0;
 }
 

--- a/frontend/tests/crafting.test.js
+++ b/frontend/tests/crafting.test.js
@@ -10,10 +10,9 @@ test("craftRecipe consumes ingredients and adds item", () => {
   const recipe = RECIPES.find((r) => r.id === "zombie_essence");
   const success = craftRecipe(inv, recipe);
   assert.strictEqual(success, true);
-  assert.strictEqual(
-    inv.slots.some((s) => s.item === "zombie_essence"),
-    true,
-  );
+  const inInv = inv.slots.some((s) => s.item === "zombie_essence");
+  const inBar = inv.hotbar.some((s) => s.item === "zombie_essence");
+  assert.strictEqual(inInv || inBar, true);
 });
 
 test("craft fire mutation serum", () => {
@@ -22,6 +21,11 @@ test("craft fire mutation serum", () => {
   const recipe = RECIPES.find((r) => r.id === "mutation_serum_fire");
   const success = craftRecipe(inv, recipe);
   assert.strictEqual(success, true);
-  assert.strictEqual(inv.slots.some((s) => s.item === "mutation_serum_fire"), true);
-  assert.strictEqual(inv.slots.some((s) => s.item === "fire_core"), false);
+  const inInv = inv.slots.some((s) => s.item === "mutation_serum_fire");
+  const inBar = inv.hotbar.some((s) => s.item === "mutation_serum_fire");
+  assert.strictEqual(inInv || inBar, true);
+  const coresLeft = inv.slots
+    .concat(inv.hotbar)
+    .some((s) => s.item === "fire_core");
+  assert.strictEqual(coresLeft, false);
 });

--- a/frontend/tests/inventory.test.js
+++ b/frontend/tests/inventory.test.js
@@ -4,7 +4,6 @@ import {
   createInventory,
   addItem,
   consumeHotbarItem,
-  moveToHotbar,
   swapHotbar,
   moveFromHotbar,
   countItem,
@@ -13,19 +12,18 @@ import {
   getActiveHotbarItem,
 } from "../src/inventory.js";
 
-test("addItem stacks and fills slots", () => {
+test("addItem prioritizes hotbar then stacks", () => {
   const inv = createInventory(1, 2);
   assert.strictEqual(addItem(inv, "core", 5), true);
-  assert.strictEqual(inv.slots[0].count, 5);
+  assert.strictEqual(inv.hotbar[0].count, 5);
   assert.strictEqual(addItem(inv, "core", 6), true);
-  assert.strictEqual(inv.slots[0].count, 10);
-  assert.strictEqual(inv.slots[1].count, 1);
+  assert.strictEqual(inv.hotbar[0].count, 10);
+  assert.strictEqual(inv.hotbar[1].count, 1);
 });
 
 test("consumeHotbarItem reduces count", () => {
   const inv = createInventory();
   addItem(inv, "flesh", 1);
-  moveToHotbar(inv, 0, 0);
   const item = consumeHotbarItem(inv, 0);
   assert.strictEqual(item, "flesh");
   assert.strictEqual(inv.hotbar[0].item, null);
@@ -34,7 +32,6 @@ test("consumeHotbarItem reduces count", () => {
 test("countItem totals across slots and hotbar", () => {
   const inv = createInventory();
   addItem(inv, "core", 3);
-  moveToHotbar(inv, 0, 0);
   addItem(inv, "core", 2);
   assert.strictEqual(countItem(inv, "core"), 5);
 });
@@ -52,8 +49,6 @@ test("swapHotbar exchanges slots", () => {
   const inv = createInventory();
   addItem(inv, "core", 1);
   addItem(inv, "flesh", 1);
-  moveToHotbar(inv, 0, 0);
-  moveToHotbar(inv, 1, 1);
   swapHotbar(inv, 0, 1);
   assert.strictEqual(inv.hotbar[0].item, "flesh");
   assert.strictEqual(inv.hotbar[1].item, "core");
@@ -62,7 +57,6 @@ test("swapHotbar exchanges slots", () => {
 test("moveFromHotbar moves item back to inventory", () => {
   const inv = createInventory();
   addItem(inv, "core", 1);
-  moveToHotbar(inv, 0, 0);
   moveFromHotbar(inv, 0, 1);
   assert.strictEqual(inv.hotbar[0].item, null);
   assert.strictEqual(inv.slots[1].item, "core");
@@ -71,7 +65,7 @@ test("moveFromHotbar moves item back to inventory", () => {
 test("setActiveHotbar updates active slot", () => {
   const inv = createInventory();
   addItem(inv, "core", 1);
-  moveToHotbar(inv, 0, 2);
+  swapHotbar(inv, 0, 2);
   setActiveHotbar(inv, 2);
   const slot = getActiveHotbarItem(inv);
   assert.strictEqual(inv.active, 2);


### PR DESCRIPTION
## Summary
- add hotbar-first logic in `addItem`
- document how pickups go to the hotbar first
- adjust crafting & inventory unit tests for new behavior

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_686a9ba233688323936736c270cbe5c5