### PR TITLE
Add fireball skill tree UI

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -24,6 +24,7 @@ The arena contains a baseball bat that starts on the ground. It now appears usin
 ## Inventory System
 
 Press **I** (or **E**) to open the 5x5 inventory grid. Keys are matched case-insensitively so holding Shift won't prevent the menus from toggling. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Newly picked up items fill the first empty hotbar slot before using inventory space. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
+Press **K** to open the skill tree and spend mutation points.
 Inventory and hotbar slots now display the item icons found in the `assets` folder. If an icon is missing for an item, a `?` will appear instead.
 
 ## Zombie Drops
@@ -48,9 +49,8 @@ Some zombies emerge imbued with flame. These **Fire Zombies** appear with a red 
 
 Collecting Fire Cores unlocks a new recipe:
 
-- **Fire Mutation Serum** - Combine three Fire Cores to craft. Right-click the serum in your inventory or hotbar to inject it and gain the Fireball ability for the rest of the current game.
+- **Fire Mutation Serum** - Combine three Fire Cores to craft. Right-click the serum in your inventory or hotbar to inject it. Each injection grants one **Fire Mutation Point** you can spend in the skill tree (press **K** to open).
 
 ## Fireball Ability
 
-Injecting the serum adds a new _Fireball_ entry to your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Spacebar** to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears.
-Starting a new game resets this ability so you must craft the serum again in future runs.
+Spend **2 Fire Mutation Points** in the skill tree to unlock the _Fireball_ ability. Unlocking places a Fireball icon in your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Spacebar** to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears. Starting a new game resets points and skills so you must craft the serum again in future runs.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -165,6 +165,49 @@
         style="height: 100%; width: 0; background: green"
       ></div>
     </div>
+    <div
+      id="skillTree"
+      style="
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: rgba(0, 0, 0, 0.7);
+        padding: 0;
+        display: none;
+        color: white;
+      "
+    >
+      <div
+        style="
+          display: flex;
+          justify-content: space-between;
+          background: rgba(255, 255, 255, 0.1);
+          cursor: move;
+          padding: 4px;
+        "
+        id="skillTreeBar"
+      >
+        <span>Skill Tree</span>
+        <button
+          id="skillTreeClose"
+          style="background: none; border: none; color: white"
+        >
+          x
+        </button>
+      </div>
+      <div style="padding: 8px">
+        <div id="skillPoints" style="margin-bottom: 8px"></div>
+        <div
+          id="skillGrid"
+          style="
+            display: grid;
+            grid-template-columns: repeat(3, 60px);
+            gap: 8px;
+          "
+        ></div>
+      </div>
+    </div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/frontend/src/player.js
+++ b/frontend/src/player.js
@@ -9,6 +9,7 @@ export function createPlayer(PLAYER_MAX_HEALTH) {
     facing: { x: 1, y: 0 },
     swingTimer: 0,
     abilities: { fireball: false },
+    fireMutationPoints: 0,
   };
 }
 
@@ -18,4 +19,5 @@ export function resetPlayerForNewGame(player, PLAYER_MAX_HEALTH) {
   player.weapon = null;
   player.swingTimer = 0;
   player.abilities.fireball = false;
+  player.fireMutationPoints = 0;
 }

--- a/frontend/src/skill_tree.js
+++ b/frontend/src/skill_tree.js
@@ -1,0 +1,16 @@
+export function unlockFireball(player, inventory, addItem, moveToHotbar) {
+  if (player.fireMutationPoints < 2 || player.abilities.fireball) return false;
+  player.fireMutationPoints -= 2;
+  player.abilities.fireball = true;
+  if (
+    !inventory.hotbar.some((s) => s.item === "fireball_spell") &&
+    !inventory.slots.some((s) => s.item === "fireball_spell")
+  ) {
+    const added = addItem(inventory, "fireball_spell", 1);
+    if (added) {
+      const idx = inventory.slots.findIndex((s) => s.item === "fireball_spell");
+      if (idx !== -1) moveToHotbar(inventory, idx, 0);
+    }
+  }
+  return true;
+}

--- a/frontend/tests/loot.test.js
+++ b/frontend/tests/loot.test.js
@@ -19,7 +19,10 @@ test("dropLoot gives fire core for fire zombie", () => {
   withRandomValues([0.5, 1, 1, 1], () => {
     dropLoot({ x: 0, y: 0, variant: "fire" }, world);
   });
-  assert.strictEqual(world.some((it) => it.type === "fire_core"), true);
+  assert.strictEqual(
+    world.some((it) => it.type === "fire_core"),
+    true,
+  );
 });
 
 test("dropLoot does not give fire core for normal zombie", () => {
@@ -27,5 +30,8 @@ test("dropLoot does not give fire core for normal zombie", () => {
   withRandomValues([0.5, 1, 1, 1], () => {
     dropLoot({ x: 0, y: 0, variant: "normal" }, world);
   });
-  assert.strictEqual(world.some((it) => it.type === "fire_core"), false);
+  assert.strictEqual(
+    world.some((it) => it.type === "fire_core"),
+    false,
+  );
 });

--- a/frontend/tests/skill_tree.test.js
+++ b/frontend/tests/skill_tree.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { unlockFireball } from "../src/skill_tree.js";
+import { createPlayer } from "../src/player.js";
+import { createInventory } from "../src/inventory.js";
+import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
+import { addItem, moveToHotbar } from "../src/inventory.js";
+
+// simple helper to mimic unlock sequence
+function setup() {
+  const player = createPlayer(PLAYER_MAX_HEALTH);
+  const inv = createInventory();
+  player.fireMutationPoints = 2;
+  return { player, inv };
+}
+
+test("unlockFireball consumes points and adds item", () => {
+  const { player, inv } = setup();
+  const res = unlockFireball(player, inv, addItem, moveToHotbar);
+  assert.strictEqual(res, true);
+  assert.strictEqual(player.fireMutationPoints, 0);
+  assert.strictEqual(player.abilities.fireball, true);
+  assert.strictEqual(inv.hotbar[0].item, "fireball_spell");
+});


### PR DESCRIPTION
## Summary
- implement basic skill tree with Fireball unlock
- grant mutation points from mutation serum
- update fireball icon and integrate new skill tree logic
- document new skill tree controls
- add unit test for skill tree unlock

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aa8baf92483238da8ebec4916dd22