### PR TITLE
Remove turret code and update docs

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -19,7 +19,7 @@ The canvas now automatically resizes to fill the entire browser window so the ac
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
 The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
 
-The arena contains a baseball bat that starts on the ground. It now appears using its bat icon rather than an orange dot. When collected it automatically occupies the first open hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the spacebar to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Turrets no longer spawn automatically; future updates will let players place them manually.
+The arena contains a baseball bat that starts on the ground. It now appears using its bat icon rather than an orange dot. When collected it automatically occupies the first open hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the spacebar to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Earlier builds included turrets, but they have been removed to simplify gameplay.
 
 ## Inventory System
 

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -122,26 +122,6 @@ export const PLAYER_MAX_HEALTH = 10;
 export const SEGMENT_SIZE = 40;
 export const TRIGGER_DISTANCE = 60;
 
-export function createTurret(x, y) {
-  return { x, y, cooldown: 0 };
-}
-
-export const TURRET_RANGE = 100;
-export const TURRET_RELOAD = 30;
-
-export function spawnTurret(width, height, walls = []) {
-  let turret;
-  let attempts = 0;
-  do {
-    turret = createTurret(Math.random() * width, Math.random() * height);
-    attempts++;
-  } while (
-    attempts < 20 &&
-    walls.some((w) => circleRectColliding(turret, w, 10))
-  );
-  return turret;
-}
-
 export function generateWalls(width, height, count = 3) {
   const walls = [];
   const gridW = Math.floor(width / SEGMENT_SIZE);
@@ -327,23 +307,6 @@ export function moveZombie(zombie, player, walls, speed, width, height) {
     zombie.x = prevX;
     zombie.y = prevY;
   }
-}
-
-export function updateTurrets(turrets, zombies, onKill = () => {}) {
-  turrets.forEach((t) => {
-    if (t.cooldown > 0) {
-      t.cooldown--;
-      return;
-    }
-    const idx = zombies.findIndex(
-      (z) => Math.hypot(z.x - t.x, z.y - t.y) <= TURRET_RANGE,
-    );
-    if (idx !== -1) {
-      const dead = zombies.splice(idx, 1)[0];
-      onKill(dead);
-      t.cooldown = TURRET_RELOAD;
-    }
-  });
 }
 
 export function createWeapon(x, y, type = "baseball_bat", damage = 1) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,7 +7,6 @@ import {
   generateWalls,
   circleRectColliding,
   SEGMENT_SIZE,
-  updateTurrets,
   spawnWeapon,
   attackZombies,
   attackZombiesWithKills,
@@ -35,6 +34,7 @@ import { RECIPES, canCraft, craftRecipe } from "./crafting.js";
 import { dropLoot } from "./loot.js";
 import { createFireball, updateFireballs } from "./spells.js";
 import { unlockFireball } from "./skill_tree.js";
+import { makeDraggable } from "./ui.js";
 
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
@@ -106,7 +106,6 @@ function drawSprite(ctx, img, x, y, facing, size = 32) {
 
 const player = createPlayer(PLAYER_MAX_HEALTH);
 let zombies = [];
-let turrets = [];
 let walls = [];
 let weapon = null;
 let spawnTimer = 0;
@@ -472,29 +471,6 @@ function toggleSkillTree(open) {
   }
 }
 
-function makeDraggable(div, bar, closeBtn, posStore, toggleFn) {
-  let dragging = false;
-  let offsetX = 0;
-  let offsetY = 0;
-  bar.addEventListener("mousedown", (e) => {
-    dragging = true;
-    offsetX = e.clientX - div.offsetLeft;
-    offsetY = e.clientY - div.offsetTop;
-    div.style.transform = "none";
-  });
-  document.addEventListener("mousemove", (e) => {
-    if (!dragging) return;
-    posStore.left = e.clientX - offsetX;
-    posStore.top = e.clientY - offsetY;
-    div.style.left = posStore.left + "px";
-    div.style.top = posStore.top + "px";
-  });
-  document.addEventListener("mouseup", () => {
-    dragging = false;
-  });
-  closeBtn.addEventListener("click", () => toggleFn(false));
-}
-
 function resizeCanvas() {
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
@@ -511,7 +487,6 @@ function startGame() {
 
 function resetGame() {
   zombies = [];
-  turrets = [];
   // Use more walls now that the canvas covers the full screen
   walls = generateWalls(canvas.width, canvas.height, 20);
   spawnDoor = createSpawnDoor(canvas.width, canvas.height, walls);
@@ -796,9 +771,6 @@ function update() {
   });
 
   updateFireballs(fireballs, zombies, walls, (z) => dropLoot(z, worldItems));
-
-  updateTurrets(turrets, zombies, (z) => dropLoot(z, worldItems));
-
   if (pickupMessageTimer > 0) {
     pickupMessageTimer--;
     if (pickupMessageTimer === 0) pickupMsg.textContent = "";
@@ -880,13 +852,6 @@ function render() {
     ctx.fillRect(z.x - 10, z.y - 16, 20, 4);
     ctx.fillStyle = "lime";
     ctx.fillRect(z.x - 10, z.y - 16, (z.health / ZOMBIE_MAX_HEALTH) * 20, 4);
-  });
-
-  ctx.fillStyle = "blue";
-  turrets.forEach((t) => {
-    ctx.beginPath();
-    ctx.arc(t.x, t.y, 8, 0, Math.PI * 2);
-    ctx.fill();
   });
 
   // The overlay div already shows the Game Over message

--- a/frontend/src/ui.js
+++ b/frontend/src/ui.js
@@ -1,0 +1,22 @@
+export function makeDraggable(div, bar, closeBtn, posStore, toggleFn) {
+  let dragging = false;
+  let offsetX = 0;
+  let offsetY = 0;
+  bar.addEventListener("mousedown", (e) => {
+    dragging = true;
+    offsetX = e.clientX - div.offsetLeft;
+    offsetY = e.clientY - div.offsetTop;
+    div.style.transform = "none";
+  });
+  document.addEventListener("mousemove", (e) => {
+    if (!dragging) return;
+    posStore.left = e.clientX - offsetX;
+    posStore.top = e.clientY - offsetY;
+    div.style.left = posStore.left + "px";
+    div.style.top = posStore.top + "px";
+  });
+  document.addEventListener("mouseup", () => {
+    dragging = false;
+  });
+  closeBtn.addEventListener("click", () => toggleFn(false));
+}

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -13,10 +13,6 @@ import {
   findPath,
   hasLineOfSight,
   moveZombie,
-  spawnTurret,
-  updateTurrets,
-  TURRET_RANGE,
-  TURRET_RELOAD,
   attackZombies,
   attackZombiesWithKills,
   ZOMBIE_MAX_HEALTH,
@@ -151,22 +147,6 @@ test("moveZombie follows grid path when blocked", () => {
   // First path step keeps x ~20 but increases y toward open space
   assert(Math.abs(zombie.x - 20) < 1e-6);
   assert(zombie.y > 20);
-});
-
-test("spawnTurret avoids walls", () => {
-  const wall = { x: 40, y: 40, size: SEGMENT_SIZE };
-  for (let i = 0; i < 20; i++) {
-    const t = spawnTurret(80, 80, [wall]);
-    assert.strictEqual(circleRectColliding(t, wall, 10), false);
-  }
-});
-
-test("updateTurrets removes zombie in range", () => {
-  const turret = { x: 0, y: 0, cooldown: 0 };
-  const zombies = [{ x: TURRET_RANGE - 1, y: 0 }];
-  updateTurrets([turret], zombies);
-  assert.strictEqual(zombies.length, 0);
-  assert.strictEqual(turret.cooldown, TURRET_RELOAD);
 });
 
 test("attackZombies damages and removes zombies", () => {


### PR DESCRIPTION
## Summary
- clean up unused turret logic
- split draggable UI helper into its own module
- update zombie example docs about turret removal
- keep tests and formatting up to date

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aab2659548323a502cfef14a80a8a