### PR TITLE
Improve item usage and controls

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -18,8 +18,9 @@ The canvas now automatically resizes to fill the entire browser window so the ac
 
 Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
 The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
+The player character now always faces your mouse cursor and a small white reticle marks the target location so you can aim while moving in any direction.
 
-The arena contains a baseball bat that starts on the ground. It now appears using its bat icon rather than an orange dot. When collected it automatically occupies the first open hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the spacebar to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Earlier builds included turrets, but they have been removed to simplify gameplay.
+The arena contains a baseball bat that starts on the ground. It now appears using its bat icon rather than an orange dot. When collected it automatically occupies the first open hotbar slot. Only the item in the **active** hotbar slot can be used. The first slot is active by default and you can switch slots by pressing the number keys **1-5**. If the baseball bat is not in the active slot it cannot be swung. Press the **Space** key or left mouse button to swing when it is equipped. Zombies hit by the swing take damage, are pushed back slightly, and can be struck from a small distance away. Earlier builds included turrets, but they have been removed to simplify gameplay.
 
 ## Inventory System
 
@@ -41,7 +42,7 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 
 Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box can hold a single Medkit with a 64% chance. If found and there is room in your hotbar or inventory, the Medkit is automatically added. Otherwise, the box keeps the item and displays "Inventory Full". Empty boxes show "Container Empty" and cannot be looted again. Opened boxes appear faded so you know they have been searched.
 
-Using a Medkit from the hotbar restores up to 3 health without exceeding your maximum.
+Equip a Medkit and press the **Space** key or left mouse button to restore up to 3 health without exceeding your maximum.
 
 ## Fire Zombies
 
@@ -49,8 +50,8 @@ Some zombies emerge imbued with flame. These **Fire Zombies** appear with a red 
 
 Collecting Fire Cores unlocks a new recipe:
 
-- **Fire Mutation Serum** - Combine three Fire Cores to craft. Right-click the serum in your inventory or hotbar to inject it. Each injection grants one **Fire Mutation Point** you can spend in the skill tree (press **K** to open).
+- **Fire Mutation Serum** - Combine three Fire Cores to craft. Equip the serum and press the **Space** key or left mouse button to inject it. Each injection grants one **Fire Mutation Point** you can spend in the skill tree (press **K** to open).
 
 ## Fireball Ability
 
-Spend **2 Fire Mutation Points** in the skill tree to unlock the _Fireball_ ability. Unlocking places a Fireball icon in your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Spacebar** to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears. Starting a new game resets points and skills so you must craft the serum again in future runs.
+Spend **2 Fire Mutation Points** in the skill tree to unlock the _Fireball_ ability. Unlocking places a Fireball icon in your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Space** or left mouse button to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears. Starting a new game resets points and skills so you must craft the serum again in future runs.

--- a/frontend/src/items.js
+++ b/frontend/src/items.js
@@ -1,0 +1,15 @@
+export const CONSUMABLE_ITEMS = new Set(["medkit", "mutation_serum_fire"]);
+
+import { PLAYER_MAX_HEALTH } from "./game_logic.js";
+
+export function applyConsumableEffect(player, itemId) {
+  if (itemId === "medkit") {
+    player.health = Math.min(PLAYER_MAX_HEALTH, player.health + 3);
+    return true;
+  }
+  if (itemId === "mutation_serum_fire") {
+    player.fireMutationPoints += 1;
+    return true;
+  }
+  return false;
+}

--- a/frontend/tests/items.test.js
+++ b/frontend/tests/items.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPlayer } from "../src/player.js";
+import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
+import { applyConsumableEffect } from "../src/items.js";
+
+test("applyConsumableEffect heals with medkit", () => {
+  const p = createPlayer(PLAYER_MAX_HEALTH);
+  p.health = 5;
+  const res = applyConsumableEffect(p, "medkit");
+  assert.strictEqual(res, true);
+  assert.strictEqual(p.health, 8);
+});
+
+test("applyConsumableEffect grants mutation point", () => {
+  const p = createPlayer(PLAYER_MAX_HEALTH);
+  const res = applyConsumableEffect(p, "mutation_serum_fire");
+  assert.strictEqual(res, true);
+  assert.strictEqual(p.fireMutationPoints, 1);
+});
+
+test("applyConsumableEffect returns false for unknown item", () => {
+  const p = createPlayer(PLAYER_MAX_HEALTH);
+  const res = applyConsumableEffect(p, "fire_core");
+  assert.strictEqual(res, false);
+});


### PR DESCRIPTION
## Summary
- add `items.js` with helper for consumable effects
- include new unit tests for consumables
- update player control logic to use mouse or space to activate items
- show aim reticle and rotate player toward mouse
- keep crafting and skill menus in sync
- document new controls and behavior

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aae93d6088323859256f58c79324d