### PR TITLE
Fix inventory/hotbar swapping with empty slots

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -24,7 +24,7 @@ The arena contains a baseball bat that starts on the ground. It now appears usin
 
 ## Inventory System
 
-Press **I** (or **E**) to open the 5x5 inventory grid. Keys are matched case-insensitively so holding Shift won't prevent the menus from toggling. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Newly picked up items fill the first empty hotbar slot before using inventory space. Drag to rearrange items or right click to move them to the hotbar. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
+Press **I** (or **E**) to open the 5x5 inventory grid. Keys are matched case-insensitively so holding Shift won't prevent the menus from toggling. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Newly picked up items fill the first empty hotbar slot before using inventory space. Drag to rearrange items or right click to move them to the hotbar. Clicking any inventory slot and then a hotbar slot (or vice versa) now swaps their contents even if one is empty. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
 Press **K** to open the skill tree and spend mutation points.
 Inventory and hotbar slots now display the item icons found in the `assets` folder. If an icon is missing for an item, a `?` will appear instead.
 

--- a/frontend/src/inventory.js
+++ b/frontend/src/inventory.js
@@ -62,6 +62,12 @@ export function swapHotbar(inv, indexA, indexB) {
   inv.hotbar[indexB] = tmp;
 }
 
+export function swapInventoryHotbar(inv, invIndex, hotbarIndex) {
+  const tmp = inv.slots[invIndex];
+  inv.slots[invIndex] = inv.hotbar[hotbarIndex];
+  inv.hotbar[hotbarIndex] = tmp;
+}
+
 export function moveFromHotbar(inv, hotbarIndex, invIndex) {
   const slot = inv.hotbar[hotbarIndex];
   inv.slots[invIndex] = slot;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -24,6 +24,7 @@ import {
   moveToHotbar,
   moveFromHotbar,
   swapHotbar,
+  swapInventoryHotbar,
   consumeHotbarItem,
   countItem,
   removeItem,
@@ -190,8 +191,7 @@ function renderInventory() {
         if (selectedSlot.type === "inventory") {
           moveItem(inventory, selectedSlot.index, i);
         } else {
-          // moving from hotbar to inventory
-          moveFromHotbar(inventory, selectedSlot.index, i);
+          swapInventoryHotbar(inventory, i, selectedSlot.index);
         }
         selectedSlot = null;
       }
@@ -263,7 +263,7 @@ function renderHotbar() {
         if (selectedSlot.type === "hotbar") {
           swapHotbar(inventory, selectedSlot.index, i);
         } else {
-          moveToHotbar(inventory, selectedSlot.index, i);
+          swapInventoryHotbar(inventory, selectedSlot.index, i);
         }
         selectedSlot = null;
       }

--- a/frontend/tests/inventory.test.js
+++ b/frontend/tests/inventory.test.js
@@ -5,6 +5,7 @@ import {
   addItem,
   consumeHotbarItem,
   swapHotbar,
+  swapInventoryHotbar,
   moveFromHotbar,
   countItem,
   removeItem,
@@ -70,4 +71,15 @@ test("setActiveHotbar updates active slot", () => {
   const slot = getActiveHotbarItem(inv);
   assert.strictEqual(inv.active, 2);
   assert.strictEqual(slot.item, "core");
+});
+
+test("swapInventoryHotbar exchanges inventory and hotbar", () => {
+  const inv = createInventory();
+  addItem(inv, "core", 1);
+  addItem(inv, "flesh", 1);
+  // move core to inventory slot 1, flesh remains in hotbar 1
+  moveFromHotbar(inv, 0, 1);
+  swapInventoryHotbar(inv, 1, 1);
+  assert.strictEqual(inv.slots[1].item, "flesh");
+  assert.strictEqual(inv.hotbar[1].item, "core");
 });


### PR DESCRIPTION
## Summary
- add `swapInventoryHotbar` utility
- ensure clicking inventory and hotbar slots always swaps items
- document swap behavior
- test inventory/hotbar swapping

## Testing
- `npm test --prefix frontend`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_686ab23d6d4883239f814f4de88ed82e