### PR TITLE
Fix crafting bug and add custom cursor

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Zombie Survival</title>
+    <style>
+      body,
+      canvas {
+        cursor:
+          url("assets/cursor.png") 16 16,
+          auto;
+      }
+    </style>
   </head>
   <body>
     <canvas

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -209,6 +209,7 @@ function renderInventory() {
     });
     inventoryGrid.appendChild(div);
   });
+  if (craftingOpen) renderCrafting();
 }
 
 function renderHotbar() {
@@ -764,7 +765,6 @@ function update() {
     if (pickupMessageTimer === 0) pickupMsg.textContent = "";
   }
 
-  if (craftingOpen) renderCrafting();
   if (skillTreeOpen) renderSkillTree();
 }
 


### PR DESCRIPTION
## Summary
- use custom cursor graphic
- fix crafting items not clickable by stopping constant re-renders
- refresh crafting list when inventory updates

## Testing
- `npx prettier -w frontend/index.html frontend/src/main.js`
- `black backend/app backend/tests`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab3bd45348323b7c98e9f0ddea10d