### PR TITLE
Add hotbar cooldown indicator

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -27,6 +27,7 @@ The arena contains a baseball bat that starts on the ground. It now appears usin
 Press **I** (or **E**) to open the 5x5 inventory grid. Keys are matched case-insensitively so holding Shift won't prevent the menus from toggling. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Newly picked up items fill the first empty hotbar slot before using inventory space. Drag to rearrange items or right click to move them to the hotbar. Clicking any inventory slot and then a hotbar slot (or vice versa) now swaps their contents even if one is empty. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
 Press **K** to open the skill tree and spend mutation points.
 Inventory and hotbar slots now display the item icons found in the `assets` folder. If an icon is missing for an item, a `?` will appear instead.
+Hotbar items with an active cooldown display a gray, semi-transparent circle that recedes clockwise as the timer expires.
 
 ## Zombie Drops
 

--- a/frontend/src/cooldowns.js
+++ b/frontend/src/cooldowns.js
@@ -1,0 +1,5 @@
+export function getItemCooldown(id, player, fireballCooldown) {
+  if (id === "fireball_spell") return { remaining: fireballCooldown, max: 15 };
+  if (id === "baseball_bat") return { remaining: player.swingTimer, max: 10 };
+  return { remaining: 0, max: 0 };
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -38,6 +38,7 @@ import { unlockFireball } from "./skill_tree.js";
 import { makeDraggable } from "./ui.js";
 
 import { applyConsumableEffect, CONSUMABLE_ITEMS } from "./items.js";
+import { getItemCooldown } from "./cooldowns.js";
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
 
@@ -182,6 +183,20 @@ function renderInventory() {
           fontSize: "10px",
         });
         div.appendChild(count);
+      }
+
+      const { remaining, max } = getItemCooldown(slot.item);
+      if (max > 0 && remaining > 0) {
+        const deg = (remaining / max) * 360;
+        const overlay = document.createElement("div");
+        Object.assign(overlay.style, {
+          position: "absolute",
+          inset: "0",
+          borderRadius: "2px",
+          pointerEvents: "none",
+          background: `conic-gradient(from -90deg, rgba(128,128,128,0.6) 0deg ${deg}deg, transparent ${deg}deg 360deg)`,
+        });
+        div.appendChild(overlay);
       }
     }
     div.addEventListener("click", () => {
@@ -766,6 +781,8 @@ function update() {
   }
 
   if (skillTreeOpen) renderSkillTree();
+
+  renderHotbar();
 }
 
 function render() {

--- a/frontend/tests/cooldowns.test.js
+++ b/frontend/tests/cooldowns.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getItemCooldown } from "../src/cooldowns.js";
+
+test("getItemCooldown handles fireball", () => {
+  const res = getItemCooldown("fireball_spell", { swingTimer: 0 }, 7);
+  assert.deepEqual(res, { remaining: 7, max: 15 });
+});
+
+test("getItemCooldown handles baseball bat", () => {
+  const res = getItemCooldown("baseball_bat", { swingTimer: 3 }, 0);
+  assert.deepEqual(res, { remaining: 3, max: 10 });
+});
+
+test("getItemCooldown unknown item", () => {
+  const res = getItemCooldown("foo", { swingTimer: 2 }, 1);
+  assert.deepEqual(res, { remaining: 0, max: 0 });
+});


### PR DESCRIPTION
## Summary
- implement `getItemCooldown` utility
- show cooldown overlay on hotbar items
- call `renderHotbar` every frame so cooldowns animate
- document hotbar cooldown indicator in zombie_game docs
- test cooldown utility

## Testing
- `npx prettier -w frontend/src/main.js frontend/src/cooldowns.js frontend/tests/cooldowns.test.js docs/zombie_game.md`
- `npm test --prefix frontend`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_686ac796c0c88323b463c2321ace2a60