### PR TITLE
Implement fireball skill upgrades

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -56,3 +56,13 @@ Collecting Fire Cores unlocks a new recipe:
 ## Fireball Ability
 
 Spend **2 Fire Mutation Points** in the skill tree to unlock the _Fireball_ ability. Unlocking places a Fireball icon in your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Space** or left mouse button to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears. Starting a new game resets points and skills so you must craft the serum again in future runs.
+
+### Fireball Upgrades
+
+After unlocking the ability you can spend more points to enhance it:
+
+| Level | Effect                                   | Cost     |
+| ----- | ---------------------------------------- | -------- |
+| **1** | Moderate damage, small explosion         | Included |
+| **2** | Increased damage & radius (+25%)         | 2 points |
+| **3** | Larger radius (+50%), pierces one zombie | 3 points |

--- a/frontend/src/player.js
+++ b/frontend/src/player.js
@@ -8,7 +8,7 @@ export function createPlayer(PLAYER_MAX_HEALTH) {
     weapon: null,
     facing: { x: 1, y: 0 },
     swingTimer: 0,
-    abilities: { fireball: false },
+    abilities: { fireball: false, fireballLevel: 0 },
     fireMutationPoints: 0,
   };
 }
@@ -19,5 +19,6 @@ export function resetPlayerForNewGame(player, PLAYER_MAX_HEALTH) {
   player.weapon = null;
   player.swingTimer = 0;
   player.abilities.fireball = false;
+  player.abilities.fireballLevel = 0;
   player.fireMutationPoints = 0;
 }

--- a/frontend/src/skill_tree.js
+++ b/frontend/src/skill_tree.js
@@ -1,15 +1,24 @@
-export function unlockFireball(player, inventory, addItem, moveToHotbar) {
-  if (player.fireMutationPoints < 2 || player.abilities.fireball) return false;
-  player.fireMutationPoints -= 2;
+export function upgradeFireball(player, inventory, addItem, moveToHotbar) {
+  const level = player.abilities.fireballLevel || 0;
+  const costs = [0, 2, 2, 3];
+  if (level >= 3) return false;
+  const cost = costs[level + 1];
+  if (player.fireMutationPoints < cost) return false;
+  player.fireMutationPoints -= cost;
   player.abilities.fireball = true;
-  if (
-    !inventory.hotbar.some((s) => s.item === "fireball_spell") &&
-    !inventory.slots.some((s) => s.item === "fireball_spell")
-  ) {
-    const added = addItem(inventory, "fireball_spell", 1);
-    if (added) {
-      const idx = inventory.slots.findIndex((s) => s.item === "fireball_spell");
-      if (idx !== -1) moveToHotbar(inventory, idx, 0);
+  player.abilities.fireballLevel = level + 1;
+  if (level === 0) {
+    if (
+      !inventory.hotbar.some((s) => s.item === "fireball_spell") &&
+      !inventory.slots.some((s) => s.item === "fireball_spell")
+    ) {
+      const added = addItem(inventory, "fireball_spell", 1);
+      if (added) {
+        const idx = inventory.slots.findIndex(
+          (s) => s.item === "fireball_spell",
+        );
+        if (idx !== -1) moveToHotbar(inventory, idx, 0);
+      }
     }
   }
   return true;

--- a/frontend/src/spells.js
+++ b/frontend/src/spells.js
@@ -1,15 +1,31 @@
 export const FIREBALL_SPEED = 3;
 export const FIREBALL_RANGE = 8 * 40; // 8 tiles assuming SEGMENT_SIZE=40
-export const FIREBALL_DAMAGE = 3;
+export const FIREBALL_BASE_DAMAGE = 3;
+export const FIREBALL_BASE_RADIUS = 20;
+
+export function fireballStats(level) {
+  let damage = FIREBALL_BASE_DAMAGE;
+  let radius = FIREBALL_BASE_RADIUS;
+  let pierce = 0;
+  if (level >= 2) {
+    damage = Math.round(FIREBALL_BASE_DAMAGE * 1.25);
+    radius = Math.round(FIREBALL_BASE_RADIUS * 1.25);
+  }
+  if (level >= 3) {
+    radius = Math.round(FIREBALL_BASE_RADIUS * 1.5);
+    pierce = 1;
+  }
+  return { damage, radius, pierce };
+}
 
 import { circleRectColliding, isColliding } from "./game_logic.js";
-
-export function createFireball(x, y, direction) {
+export function createFireball(x, y, direction, level = 1) {
   const len = Math.hypot(direction.x, direction.y);
   if (len === 0) return null;
   const vx = (direction.x / len) * FIREBALL_SPEED;
   const vy = (direction.y / len) * FIREBALL_SPEED;
-  return { x, y, vx, vy, traveled: 0 };
+  const { damage, radius, pierce } = fireballStats(level);
+  return { x, y, vx, vy, traveled: 0, damage, radius, pierce };
 }
 
 export function updateFireballs(fireballs, zombies, walls, onKill = () => {}) {
@@ -18,24 +34,41 @@ export function updateFireballs(fireballs, zombies, walls, onKill = () => {}) {
     fb.x += fb.vx;
     fb.y += fb.vy;
     fb.traveled += Math.hypot(fb.vx, fb.vy);
-    let remove = fb.traveled >= FIREBALL_RANGE;
-    if (!remove && walls.some((w) => circleRectColliding(fb, w, 4))) {
-      remove = true;
-    }
-    if (!remove) {
+    let explode = false;
+    if (fb.traveled >= FIREBALL_RANGE) {
+      explode = true;
+    } else if (walls.some((w) => circleRectColliding(fb, w, 4))) {
+      explode = true;
+    } else {
       for (let j = zombies.length - 1; j >= 0; j--) {
         const z = zombies[j];
         if (isColliding(fb, z, 4)) {
-          z.health -= FIREBALL_DAMAGE;
+          z.health -= fb.damage;
           if (z.health <= 0) {
             zombies.splice(j, 1);
             onKill(z);
           }
-          remove = true;
+          if (fb.pierce > 0) {
+            fb.pierce -= 1;
+          } else {
+            explode = true;
+          }
           break;
         }
       }
     }
-    if (remove) fireballs.splice(i, 1);
+    if (explode) {
+      for (let j = zombies.length - 1; j >= 0; j--) {
+        const z = zombies[j];
+        if (Math.hypot(z.x - fb.x, z.y - fb.y) <= fb.radius) {
+          z.health -= fb.damage;
+          if (z.health <= 0) {
+            zombies.splice(j, 1);
+            onKill(z);
+          }
+        }
+      }
+      fireballs.splice(i, 1);
+    }
   }
 }

--- a/frontend/tests/player.test.js
+++ b/frontend/tests/player.test.js
@@ -6,10 +6,12 @@ import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
 test("resetPlayerForNewGame clears abilities and restores health", () => {
   const player = createPlayer(PLAYER_MAX_HEALTH);
   player.abilities.fireball = true;
+  player.abilities.fireballLevel = 2;
   player.health = 1;
   player.weapon = { type: "bat" };
   resetPlayerForNewGame(player, PLAYER_MAX_HEALTH);
   assert.strictEqual(player.abilities.fireball, false);
+  assert.strictEqual(player.abilities.fireballLevel, 0);
   assert.strictEqual(player.health, PLAYER_MAX_HEALTH);
   assert.strictEqual(player.weapon, null);
 });

--- a/frontend/tests/skill_tree.test.js
+++ b/frontend/tests/skill_tree.test.js
@@ -1,24 +1,42 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { unlockFireball } from "../src/skill_tree.js";
-import { createPlayer } from "../src/player.js";
+import { upgradeFireball } from "../src/skill_tree.js";
+import { createPlayer, resetPlayerForNewGame } from "../src/player.js";
 import { createInventory } from "../src/inventory.js";
 import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
 import { addItem, moveToHotbar } from "../src/inventory.js";
 
-// simple helper to mimic unlock sequence
-function setup() {
+function setup(points = 2) {
   const player = createPlayer(PLAYER_MAX_HEALTH);
   const inv = createInventory();
-  player.fireMutationPoints = 2;
+  player.fireMutationPoints = points;
   return { player, inv };
 }
 
-test("unlockFireball consumes points and adds item", () => {
-  const { player, inv } = setup();
-  const res = unlockFireball(player, inv, addItem, moveToHotbar);
+test("upgradeFireball unlocks and adds item", () => {
+  const { player, inv } = setup(2);
+  const res = upgradeFireball(player, inv, addItem, moveToHotbar);
   assert.strictEqual(res, true);
   assert.strictEqual(player.fireMutationPoints, 0);
-  assert.strictEqual(player.abilities.fireball, true);
+  assert.strictEqual(player.abilities.fireballLevel, 1);
   assert.strictEqual(inv.hotbar[0].item, "fireball_spell");
+});
+
+test("upgradeFireball upgrades levels with correct costs", () => {
+  const { player, inv } = setup(7);
+  // unlock
+  assert(upgradeFireball(player, inv, addItem, moveToHotbar));
+  assert.strictEqual(player.abilities.fireballLevel, 1);
+  // level 2
+  assert(upgradeFireball(player, inv, addItem, moveToHotbar));
+  assert.strictEqual(player.abilities.fireballLevel, 2);
+  // level 3
+  assert(upgradeFireball(player, inv, addItem, moveToHotbar));
+  assert.strictEqual(player.abilities.fireballLevel, 3);
+  assert.strictEqual(player.fireMutationPoints, 0);
+  // cannot exceed max
+  assert.strictEqual(
+    upgradeFireball(player, inv, addItem, moveToHotbar),
+    false,
+  );
 });

--- a/frontend/tests/spells.test.js
+++ b/frontend/tests/spells.test.js
@@ -6,13 +6,13 @@ import { createFireball, updateFireballs } from "../src/spells.js";
 import { circleRectColliding, isColliding } from "../src/game_logic.js";
 
 test("createFireball normalizes direction", () => {
-  const fb = createFireball(0, 0, { x: 3, y: 4 });
+  const fb = createFireball(0, 0, { x: 3, y: 4 }, 1);
   assert(Math.abs(fb.vx - 1.8) < 1e-6);
   assert(Math.abs(fb.vy - 2.4) < 1e-6);
 });
 
 test("updateFireballs moves and hits zombie", () => {
-  const fireballs = [createFireball(0, 0, { x: 1, y: 0 })];
+  const fireballs = [createFireball(0, 0, { x: 1, y: 0 }, 1)];
   const zombies = [{ x: 5, y: 0, health: 3 }];
   for (let i = 0; i < 10 && fireballs.length > 0; i++) {
     updateFireballs(fireballs, zombies, []);


### PR DESCRIPTION
## Summary
- add fireball upgrade path and leveling system
- support ability levels in player data and skill tree
- enhance fireball spell with radius, damage and piercing upgrades
- document fireball upgrade levels
- update unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686afe9eb2d883238aa98b7ed467c8bb