### PR TITLE
Add wood resource and bow combat

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -41,7 +41,7 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 
 ## Containers
 
-Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box can hold a single Medkit with a 64% chance. If found and there is room in your hotbar or inventory, the Medkit is automatically added. Otherwise, the box keeps the item and displays "Inventory Full". Empty boxes show "Container Empty" and cannot be looted again. Opened boxes appear faded so you know they have been searched.
+Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box now contains either a **Medkit** or **Wood** with equal probability. If there is room in your hotbar or inventory the item is added automatically. Otherwise a brief "Inventory Full" message appears. Opened boxes appear faded so you know they have been searched.
 
 Equip a Medkit and press the **Space** key or left mouse button to restore up to 3 health without exceeding your maximum.
 
@@ -66,3 +66,12 @@ After unlocking the ability you can spend more points to enhance it:
 | **1** | Moderate damage, small explosion         | Included |
 | **2** | Increased damage & radius (+25%)         | 2 points |
 | **3** | Larger radius (+50%), pierces one zombie | 3 points |
+
+## Bow and Arrow
+
+Wood collected from containers can be crafted into ranged equipment:
+
+- **Bow** – Requires 3 Wood, 2 Zombie Teeth and 1 Core.
+- **Arrows** – Crafted in batches of 5 using 1 Wood and 1 Zombie Tooth.
+
+Equip the Bow in your hotbar. Hold the right mouse button or **Space** to aim, then release to fire an arrow toward the cursor. Each shot consumes one Arrow. The current arrow count appears below the health display and an "Out of Arrows!" notification shows when empty.

--- a/frontend/src/arrow.js
+++ b/frontend/src/arrow.js
@@ -1,0 +1,38 @@
+export const ARROW_SPEED = 3;
+export const ARROW_DAMAGE = 2;
+
+import { circleRectColliding, isColliding } from "./game_logic.js";
+
+export function createArrow(x, y, direction) {
+  const len = Math.hypot(direction.x, direction.y);
+  if (len === 0) return null;
+  const vx = (direction.x / len) * ARROW_SPEED;
+  const vy = (direction.y / len) * ARROW_SPEED;
+  return { x, y, vx, vy };
+}
+
+export function updateArrows(arrows, zombies, walls, onKill = () => {}) {
+  for (let i = arrows.length - 1; i >= 0; i--) {
+    const a = arrows[i];
+    a.x += a.vx;
+    a.y += a.vy;
+    let remove = false;
+    if (walls.some((w) => circleRectColliding(a, w, 2))) {
+      remove = true;
+    } else {
+      for (let j = zombies.length - 1; j >= 0; j--) {
+        const z = zombies[j];
+        if (isColliding(a, z, 2)) {
+          z.health -= ARROW_DAMAGE;
+          if (z.health <= 0) {
+            zombies.splice(j, 1);
+            onKill(z);
+          }
+          remove = true;
+          break;
+        }
+      }
+    }
+    if (remove) arrows.splice(i, 1);
+  }
+}

--- a/frontend/src/crafting.js
+++ b/frontend/src/crafting.js
@@ -23,6 +23,19 @@ export const RECIPES = [
     description: "Unlocks the Fireball ability.",
     ingredients: { fire_core: 3 },
   },
+  {
+    id: "bow",
+    title: "Bow",
+    description: "Simple wooden bow.",
+    ingredients: { wood: 3, teeth: 2, core: 1 },
+  },
+  {
+    id: "arrow",
+    title: "Arrows",
+    description: "Ammo for the bow.",
+    ingredients: { wood: 1, teeth: 1 },
+    output: { id: "arrow", qty: 5 },
+  },
 ];
 
 import { addItem, countItem, removeItem } from "./inventory.js";
@@ -38,5 +51,6 @@ export function craftRecipe(inv, recipe) {
   Object.entries(recipe.ingredients).forEach(([id, qty]) => {
     removeItem(inv, id, qty);
   });
-  return addItem(inv, recipe.id, 1);
+  const output = recipe.output || { id: recipe.id, qty: 1 };
+  return addItem(inv, output.id, output.qty);
 }

--- a/frontend/src/inventory.js
+++ b/frontend/src/inventory.js
@@ -1,3 +1,12 @@
+export const STACK_LIMITS = {
+  wood: 20,
+  arrow: 20,
+};
+
+export function getStackLimit(itemId) {
+  return STACK_LIMITS[itemId] || 10;
+}
+
 export function createInventory(rows = 5, cols = 5) {
   const slots = Array.from({ length: rows * cols }, () => ({
     item: null,
@@ -8,10 +17,11 @@ export function createInventory(rows = 5, cols = 5) {
 }
 
 export function addItem(inv, itemId, amount = 1) {
+  const limit = getStackLimit(itemId);
   // First fill existing stacks across hotbar and inventory
   for (const slot of [...inv.hotbar, ...inv.slots]) {
-    if (slot.item === itemId && slot.count < 10) {
-      const add = Math.min(amount, 10 - slot.count);
+    if (slot.item === itemId && slot.count < limit) {
+      const add = Math.min(amount, limit - slot.count);
       slot.count += add;
       amount -= add;
       if (amount === 0) return true;
@@ -21,7 +31,7 @@ export function addItem(inv, itemId, amount = 1) {
   // Next place new stacks into open hotbar slots
   for (const slot of inv.hotbar) {
     if (!slot.item) {
-      const add = Math.min(amount, 10);
+      const add = Math.min(amount, limit);
       slot.item = itemId;
       slot.count = add;
       amount -= add;
@@ -32,7 +42,7 @@ export function addItem(inv, itemId, amount = 1) {
   // Finally fill empty inventory slots
   for (const slot of inv.slots) {
     if (!slot.item) {
-      const add = Math.min(amount, 10);
+      const add = Math.min(amount, limit);
       slot.item = itemId;
       slot.count = add;
       amount -= add;

--- a/frontend/tests/arrow.test.js
+++ b/frontend/tests/arrow.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createArrow, updateArrows } from "../src/arrow.js";
+
+// helper stubs
+import { circleRectColliding, isColliding } from "../src/game_logic.js";
+
+test("createArrow normalizes direction", () => {
+  const a = createArrow(0, 0, { x: 3, y: 4 });
+  assert(Math.abs(a.vx - 1.8) < 1e-6);
+  assert(Math.abs(a.vy - 2.4) < 1e-6);
+});
+
+test("updateArrows hits zombie and removes", () => {
+  const arrows = [createArrow(0, 0, { x: 1, y: 0 })];
+  const zombies = [{ x: 5, y: 0, health: 2 }];
+  for (let i = 0; i < 10 && arrows.length > 0; i++) {
+    updateArrows(arrows, zombies, []);
+  }
+  assert.strictEqual(arrows.length, 0);
+  assert(zombies.length === 0 || zombies[0].health < 2);
+});

--- a/frontend/tests/inventory.test.js
+++ b/frontend/tests/inventory.test.js
@@ -23,6 +23,14 @@ test("addItem prioritizes hotbar then stacks", () => {
   assert.strictEqual(inv.hotbar[1].count, 1);
 });
 
+test("wood stacks up to 20", () => {
+  const inv = createInventory();
+  addItem(inv, "wood", 20);
+  assert.strictEqual(inv.hotbar[0].count, 20);
+  addItem(inv, "wood", 5);
+  assert.strictEqual(countItem(inv, "wood"), 25);
+});
+
 test("consumeHotbarItem reduces count", () => {
   const inv = createInventory();
   addItem(inv, "flesh", 1);


### PR DESCRIPTION
## Summary
- support per-item stack limits
- add wood item with stack size 20
- implement bow & arrow crafting and ranged combat
- allow cardboard boxes to drop wood or medkits
- spawn more cardboard boxes
- document new mechanics

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b096e8de08323a2409d6fac5c2494