### PR TITLE
Improve fireball explosion effects

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -55,7 +55,7 @@ Collecting Fire Cores unlocks a new recipe:
 
 ## Fireball Ability
 
-Spend **2 Fire Mutation Points** in the skill tree to unlock the _Fireball_ ability. Unlocking places a Fireball icon in your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Space** or left mouse button to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears. Starting a new game resets points and skills so you must craft the serum again in future runs.
+Spend **2 Fire Mutation Points** in the skill tree to unlock the _Fireball_ ability. Unlocking places a Fireball icon in your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Space** or left mouse button to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. A dashed line preview displays the path and a dotted circle shows the blast radius before you cast. When the Fireball explodes a faint red circle briefly highlights the impact area. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears. Starting a new game resets points and skills so you must craft the serum again in future runs.
 
 ### Fireball Upgrades
 

--- a/frontend/tests/spells.test.js
+++ b/frontend/tests/spells.test.js
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createFireball, updateFireballs } from "../src/spells.js";
+import {
+  createFireball,
+  updateFireballs,
+  updateExplosions,
+} from "../src/spells.js";
 
 // mocks for game_logic helpers
 import { circleRectColliding, isColliding } from "../src/game_logic.js";
@@ -14,9 +18,12 @@ test("createFireball normalizes direction", () => {
 test("updateFireballs moves and hits zombie", () => {
   const fireballs = [createFireball(0, 0, { x: 1, y: 0 }, 1)];
   const zombies = [{ x: 5, y: 0, health: 3 }];
+  const explosions = [];
   for (let i = 0; i < 10 && fireballs.length > 0; i++) {
-    updateFireballs(fireballs, zombies, []);
+    updateFireballs(fireballs, zombies, [], explosions);
+    updateExplosions(explosions);
   }
   assert.strictEqual(fireballs.length, 0);
   assert.strictEqual(zombies.length === 0 || zombies[0].health < 3, true);
+  assert(explosions.length > 0);
 });


### PR DESCRIPTION
## Summary
- enhance fireball logic with explosion previews and animations
- display fireball path and blast radius before casting
- show explosions visually when a fireball detonates
- document new behaviour in zombie game guide
- adjust tests for updated spell functions

## Testing
- `npx prettier -w frontend/src/spells.js frontend/src/main.js frontend/tests/spells.test.js docs/zombie_game.md`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b18988d34832396f0fbaba09a61d4