### PR TITLE
Improve fireball and arrow previews

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -55,17 +55,17 @@ Collecting Fire Cores unlocks a new recipe:
 
 ## Fireball Ability
 
-Spend **2 Fire Mutation Points** in the skill tree to unlock the _Fireball_ ability. Unlocking places a Fireball icon in your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Space** or left mouse button to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. A dashed line preview displays the path and a dotted circle shows the blast radius before you cast. When the Fireball explodes a faint red circle briefly highlights the impact area. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears. Starting a new game resets points and skills so you must craft the serum again in future runs.
+Spend **2 Fire Mutation Points** in the skill tree to unlock the _Fireball_ ability. Unlocking places a Fireball icon in your hotbar. Equip it like any other item by selecting the slot with the number keys. While equipped press **Space** or left mouse button to hurl a blazing projectile toward the mouse cursor. Each cast consumes one Fire Core from your inventory. The Fireball travels about eight tiles, damaging zombies it hits and dissipating on impact with walls or enemies. A dashed line preview displays the path and a dotted circle shows the blast radius before you cast. The preview shortens when a wall or zombie blocks the shot. When the Fireball explodes a faint red circle briefly highlights the impact area. If you attempt to cast without any cores a brief "Out of Fire Cores!" message appears. Starting a new game resets points and skills so you must craft the serum again in future runs.
 
 ### Fireball Upgrades
 
 After unlocking the ability you can spend more points to enhance it:
 
-| Level | Effect                                   | Cost     |
-| ----- | ---------------------------------------- | -------- |
-| **1** | Moderate damage, small explosion         | Included |
-| **2** | Increased damage & radius (+25%)         | 2 points |
-| **3** | Larger radius (+50%), pierces one zombie | 3 points |
+| Level | Effect                                            | Cost     |
+| ----- | ------------------------------------------------- | -------- |
+| **1** | Low damage, large explosion                       | Included |
+| **2** | +1 damage, +50% radius                            | 2 points |
+| **3** | +1 damage again, +100% radius, pierces one zombie | 3 points |
 
 ## Bow and Arrow
 
@@ -74,4 +74,4 @@ Wood collected from containers can be crafted into ranged equipment:
 - **Bow** – Requires 3 Wood, 2 Zombie Teeth and 1 Core.
 - **Arrows** – Crafted in batches of 5 using 1 Wood and 1 Zombie Tooth.
 
-Equip the Bow in your hotbar. Hold the right mouse button or **Space** to aim, then release to fire an arrow toward the cursor. Each shot consumes one Arrow. The current arrow count appears below the health display and an "Out of Arrows!" notification shows when empty.
+Equip the Bow in your hotbar. Hold the right mouse button or **Space** to aim, then release to fire an arrow toward the cursor. A dashed line shows where the arrow will fly and stops when hitting a wall or zombie. Each shot consumes one Arrow. The current arrow count appears below the health display and an "Out of Arrows!" notification shows when empty.

--- a/frontend/src/arrow.js
+++ b/frontend/src/arrow.js
@@ -1,7 +1,30 @@
 export const ARROW_SPEED = 3;
 export const ARROW_DAMAGE = 2;
+export const ARROW_PREVIEW_RANGE = 12 * 40;
 
 import { circleRectColliding, isColliding } from "./game_logic.js";
+
+export function predictArrowEndpoint(x, y, direction, walls, zombies = []) {
+  const len = Math.hypot(direction.x, direction.y);
+  if (len === 0) return { x, y };
+  const stepX = (direction.x / len) * ARROW_SPEED;
+  const stepY = (direction.y / len) * ARROW_SPEED;
+  let cx = x;
+  let cy = y;
+  let traveled = 0;
+  while (traveled < ARROW_PREVIEW_RANGE) {
+    cx += stepX;
+    cy += stepY;
+    traveled += Math.hypot(stepX, stepY);
+    if (walls.some((w) => circleRectColliding({ x: cx, y: cy }, w, 2))) {
+      break;
+    }
+    if (zombies.some((z) => isColliding({ x: cx, y: cy }, z, 2))) {
+      break;
+    }
+  }
+  return { x: cx, y: cy };
+}
 
 export function createArrow(x, y, direction) {
   const len = Math.hypot(direction.x, direction.y);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -40,7 +40,7 @@ import {
   fireballStats,
   updateExplosions,
 } from "./spells.js";
-import { createArrow, updateArrows } from "./arrow.js";
+import { createArrow, updateArrows, predictArrowEndpoint } from "./arrow.js";
 import { upgradeFireball } from "./skill_tree.js";
 import { makeDraggable } from "./ui.js";
 
@@ -924,9 +924,17 @@ function render() {
     ctx.fill();
   });
   if (bowAiming) {
-    ctx.strokeStyle = "white";
+    const dir = { x: mousePos.x - player.x, y: mousePos.y - player.y };
+    const end = predictArrowEndpoint(player.x, player.y, dir, walls, zombies);
+    ctx.strokeStyle = "rgba(255,255,255,0.6)";
+    ctx.setLineDash([5, 5]);
     ctx.beginPath();
-    ctx.arc(mousePos.x, mousePos.y, 5, 0, Math.PI * 2);
+    ctx.moveTo(player.x, player.y);
+    ctx.lineTo(end.x, end.y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.arc(end.x, end.y, 3, 0, Math.PI * 2);
     ctx.stroke();
   }
 
@@ -937,7 +945,13 @@ function render() {
     player.abilities.fireball
   ) {
     const dir = { x: mousePos.x - player.x, y: mousePos.y - player.y };
-    const end = predictFireballEndpoint(player.x, player.y, dir, walls);
+    const end = predictFireballEndpoint(
+      player.x,
+      player.y,
+      dir,
+      walls,
+      zombies,
+    );
     ctx.strokeStyle = "rgba(255,0,0,0.6)";
     ctx.setLineDash([5, 5]);
     ctx.beginPath();

--- a/frontend/src/spells.js
+++ b/frontend/src/spells.js
@@ -1,18 +1,19 @@
 export const FIREBALL_SPEED = 3;
 export const FIREBALL_RANGE = 8 * 40; // 8 tiles assuming SEGMENT_SIZE=40
-export const FIREBALL_BASE_DAMAGE = 3;
-export const FIREBALL_BASE_RADIUS = 20;
+export const FIREBALL_BASE_DAMAGE = 1;
+export const FIREBALL_BASE_RADIUS = 40;
 
 export function fireballStats(level) {
   let damage = FIREBALL_BASE_DAMAGE;
   let radius = FIREBALL_BASE_RADIUS;
   let pierce = 0;
   if (level >= 2) {
-    damage = Math.round(FIREBALL_BASE_DAMAGE * 1.25);
-    radius = Math.round(FIREBALL_BASE_RADIUS * 1.25);
+    damage = FIREBALL_BASE_DAMAGE * 2;
+    radius = Math.round(FIREBALL_BASE_RADIUS * 1.5);
   }
   if (level >= 3) {
-    radius = Math.round(FIREBALL_BASE_RADIUS * 1.5);
+    damage = FIREBALL_BASE_DAMAGE * 3;
+    radius = Math.round(FIREBALL_BASE_RADIUS * 2);
     pierce = 1;
   }
   return { damage, radius, pierce };
@@ -28,7 +29,7 @@ export function createFireball(x, y, direction, level = 1) {
   return { x, y, vx, vy, traveled: 0, damage, radius, pierce };
 }
 
-export function predictFireballEndpoint(x, y, direction, walls) {
+export function predictFireballEndpoint(x, y, direction, walls, zombies = []) {
   const len = Math.hypot(direction.x, direction.y);
   if (len === 0) return { x, y };
   const stepX = (direction.x / len) * FIREBALL_SPEED;
@@ -41,6 +42,9 @@ export function predictFireballEndpoint(x, y, direction, walls) {
     cy += stepY;
     traveled += Math.hypot(stepX, stepY);
     if (walls.some((w) => circleRectColliding({ x: cx, y: cy }, w, 4))) {
+      break;
+    }
+    if (zombies.some((z) => isColliding({ x: cx, y: cy }, z, 4))) {
       break;
     }
   }

--- a/frontend/tests/arrow.test.js
+++ b/frontend/tests/arrow.test.js
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createArrow, updateArrows } from "../src/arrow.js";
+import {
+  createArrow,
+  updateArrows,
+  predictArrowEndpoint,
+} from "../src/arrow.js";
 
 // helper stubs
 import { circleRectColliding, isColliding } from "../src/game_logic.js";
@@ -19,4 +23,12 @@ test("updateArrows hits zombie and removes", () => {
   }
   assert.strictEqual(arrows.length, 0);
   assert(zombies.length === 0 || zombies[0].health < 2);
+});
+
+test("predictArrowEndpoint stops at obstacles", () => {
+  const wall = { x: 10, y: -5, size: 10 };
+  const end1 = predictArrowEndpoint(0, 0, { x: 1, y: 0 }, [wall], []);
+  assert(end1.x <= 10);
+  const end2 = predictArrowEndpoint(0, 0, { x: 1, y: 0 }, [], [{ x: 5, y: 0 }]);
+  assert(end2.x <= 5);
 });

--- a/frontend/tests/spells.test.js
+++ b/frontend/tests/spells.test.js
@@ -4,6 +4,8 @@ import {
   createFireball,
   updateFireballs,
   updateExplosions,
+  fireballStats,
+  predictFireballEndpoint,
 } from "../src/spells.js";
 
 // mocks for game_logic helpers
@@ -26,4 +28,28 @@ test("updateFireballs moves and hits zombie", () => {
   assert.strictEqual(fireballs.length, 0);
   assert.strictEqual(zombies.length === 0 || zombies[0].health < 3, true);
   assert(explosions.length > 0);
+});
+
+test("fireballStats scales with level", () => {
+  const l1 = fireballStats(1);
+  const l2 = fireballStats(2);
+  const l3 = fireballStats(3);
+  assert.strictEqual(l1.damage, 1);
+  assert.strictEqual(l1.radius, 40);
+  assert.strictEqual(l2.damage, 2);
+  assert.strictEqual(l2.radius, 60);
+  assert.strictEqual(l3.damage, 3);
+  assert.strictEqual(l3.radius, 80);
+  assert.strictEqual(l3.pierce, 1);
+});
+
+test("predictFireballEndpoint stops at zombie", () => {
+  const end = predictFireballEndpoint(
+    0,
+    0,
+    { x: 1, y: 0 },
+    [],
+    [{ x: 5, y: 0 }],
+  );
+  assert(end.x <= 5);
 });


### PR DESCRIPTION
## Summary
- tweak fireball stats so level 1 does less damage but blasts are larger
- preview lines for fireballs and arrows stop at zombies or walls
- show dashed line while aiming the bow
- document updated fireball scaling and previews
- test new helper functions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b1e6eab388323ad2f2cacf24b4fa1