### PR TITLE
Fix zombie health bar rendering

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -16,7 +16,7 @@ The game runs entirely in the browser. Open `http://localhost:3000` and you will
 
 The canvas now automatically resizes to fill the entire browser window so the action takes up all available space.
 
-Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie also has a simple green bar above its head to indicate remaining health.
+Players now have a small health pool instead of dying instantly. A "Health" display shows the remaining points. Each zombie has a green health bar with a red background above its head so damage is immediately visible.
 The on-screen control instructions are fixed to the bottom-left corner so they never cover the health readout.
 The player character now always faces your mouse cursor. A custom cursor icon marks the target location so you can aim while moving in any direction.
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -992,6 +992,7 @@ function render() {
     }
     const img = z.variant === "fire" ? fireZombieSprite : zombieSprite;
     drawSprite(ctx, img, z.x, z.y, z.facing);
+    ctx.fillStyle = "red";
     ctx.fillRect(z.x - 10, z.y - 16, 20, 4);
     ctx.fillStyle = "lime";
     ctx.fillRect(z.x - 10, z.y - 16, (z.health / ZOMBIE_MAX_HEALTH) * 20, 4);


### PR DESCRIPTION
## Summary
- fix zombie health bar so damage is visible
- update docs to describe red background behind zombie health bars

## Testing
- `npm test --silent --prefix frontend`
- `pytest -q backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_686b242c98088323a1e76a65b032f416