### PR TITLE
Fix bow aiming preview not appearing

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -74,4 +74,4 @@ Wood collected from containers can be crafted into ranged equipment:
 - **Bow** – Requires 3 Wood, 2 Zombie Teeth and 1 Core.
 - **Arrows** – Crafted in batches of 5 using 1 Wood and 1 Zombie Tooth.
 
-Equip the Bow in your hotbar. Hold the right mouse button or **Space** to aim, then release to fire an arrow toward the cursor. A dashed line shows where the arrow will fly and stops when hitting a wall or zombie. Each shot consumes one Arrow. The current arrow count appears below the health display and an "Out of Arrows!" notification shows when empty.
+Equip the Bow in your hotbar. Hold the right mouse button or **Space** to aim, then release to fire an arrow toward the cursor. While aiming a dashed line previews the path and stops when hitting a wall or zombie. Each shot consumes one Arrow. The current arrow count appears below the health display and an "Out of Arrows!" notification shows when empty.

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -923,7 +923,9 @@ function render() {
     ctx.arc(a.x, a.y, 2, 0, Math.PI * 2);
     ctx.fill();
   });
-  if (bowAiming) {
+  const aimingBow =
+    player.weapon && player.weapon.type === "bow" && (keys[" "] || keys.mouse2);
+  if (aimingBow) {
     const dir = { x: mousePos.x - player.x, y: mousePos.y - player.y };
     const end = predictArrowEndpoint(player.x, player.y, dir, walls, zombies);
     ctx.strokeStyle = "rgba(255,255,255,0.6)";


### PR DESCRIPTION
## Summary
- compute bow aiming preview directly in `render`
- clarify docs about arrow path preview

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_686be9df1da483238d0ed7e42ad597a4