### PR TITLE
Fix Phoenix Revival not triggering

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -88,7 +88,9 @@ delay. Additional points add a second orb and shorten the respawn time.
 
 This ultimate skill costs **4 Fire Mutation Points** to unlock. If you would die
 with the ability ready, you instead revive with a portion of your health and a
-temporary damage boost. The skill then goes on cooldown for two minutes.
+temporary damage boost. The skill then goes on cooldown for two minutes. The
+revival check happens whenever your HP reaches zero, regardless of what caused
+the damage.
 
 | Level | Revive Health | Damage Buff | Duration | Cost |
 | ----- | ------------- | ----------- | -------- | ---- |

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,7 +16,11 @@ import {
   spawnZombieAtDoor,
   spawnContainers,
 } from "./game_logic.js";
-import { createPlayer, resetPlayerForNewGame } from "./player.js";
+import {
+  createPlayer,
+  resetPlayerForNewGame,
+  tryPhoenixRevival,
+} from "./player.js";
 import {
   createInventory,
   addItem,
@@ -680,6 +684,14 @@ function update() {
     if (player.damageBuffTimer <= 0) player.damageBuffMult = 1;
   }
 
+  if (player.health <= 0) {
+    if (!tryPhoenixRevival(player, PLAYER_MAX_HEALTH)) {
+      gameOver = true;
+      gameOverDiv.style.display = "block";
+      return;
+    }
+  }
+
   const activeSlot = getActiveHotbarItem(inventory);
   if (activeSlot && activeSlot.item === "baseball_bat") {
     player.weapon = { type: "baseball_bat", damage: 1 };
@@ -891,16 +903,7 @@ function update() {
       player.damageCooldown = 30;
       z.attackCooldown = 30;
       if (player.health <= 0) {
-        if (player.abilities.phoenixRevival && player.phoenixCooldown <= 0) {
-          const lvl = player.abilities.phoenixRevivalLevel;
-          const hpPerc = [0, 0.1, 0.3, 0.5][lvl];
-          const dmg = [0, 1.25, 1.35, 1.5][lvl];
-          const dur = [0, 300, 480, 720][lvl];
-          player.health = Math.max(1, Math.round(PLAYER_MAX_HEALTH * hpPerc));
-          player.phoenixCooldown = 7200;
-          player.damageBuffMult = dmg;
-          player.damageBuffTimer = dur;
-        } else {
+        if (!tryPhoenixRevival(player, PLAYER_MAX_HEALTH)) {
           gameOver = true;
           gameOverDiv.style.display = "block";
         }

--- a/frontend/src/player.js
+++ b/frontend/src/player.js
@@ -39,3 +39,22 @@ export function resetPlayerForNewGame(player, PLAYER_MAX_HEALTH) {
   player.damageBuffMult = 1;
   player.fireMutationPoints = 0;
 }
+
+export function tryPhoenixRevival(player, PLAYER_MAX_HEALTH) {
+  if (
+    player.abilities.phoenixRevival &&
+    player.phoenixCooldown <= 0 &&
+    player.health <= 0
+  ) {
+    const lvl = player.abilities.phoenixRevivalLevel;
+    const hpPerc = [0, 0.1, 0.3, 0.5][lvl];
+    const dmg = [0, 1.25, 1.35, 1.5][lvl];
+    const dur = [0, 300, 480, 720][lvl];
+    player.health = Math.max(1, Math.round(PLAYER_MAX_HEALTH * hpPerc));
+    player.phoenixCooldown = 7200;
+    player.damageBuffMult = dmg;
+    player.damageBuffTimer = dur;
+    return true;
+  }
+  return false;
+}

--- a/frontend/tests/phoenix.test.js
+++ b/frontend/tests/phoenix.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPlayer, tryPhoenixRevival } from "../src/player.js";
+import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
+
+test("tryPhoenixRevival revives player", () => {
+  const player = createPlayer(PLAYER_MAX_HEALTH);
+  player.abilities.phoenixRevival = true;
+  player.abilities.phoenixRevivalLevel = 1;
+  player.phoenixCooldown = 0;
+  player.health = 0;
+  const res = tryPhoenixRevival(player, PLAYER_MAX_HEALTH);
+  assert.strictEqual(res, true);
+  assert.strictEqual(player.health, 1);
+  assert.strictEqual(player.phoenixCooldown, 7200);
+  assert.strictEqual(player.damageBuffMult, 1.25);
+  assert.strictEqual(player.damageBuffTimer, 300);
+});
+
+test("tryPhoenixRevival fails when on cooldown", () => {
+  const player = createPlayer(PLAYER_MAX_HEALTH);
+  player.abilities.phoenixRevival = true;
+  player.abilities.phoenixRevivalLevel = 1;
+  player.phoenixCooldown = 10;
+  player.health = 0;
+  const res = tryPhoenixRevival(player, PLAYER_MAX_HEALTH);
+  assert.strictEqual(res, false);
+  assert.strictEqual(player.health, 0);
+});


### PR DESCRIPTION
## Summary
- added `tryPhoenixRevival` helper in `player.js`
- run phoenix revival check at the start of `update`
- use helper in zombie attack logic
- document that revival checks trigger on any source of damage
- add unit tests covering phoenix revival

## Testing
- `npm test --prefix frontend`
- `pytest -q backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_686c007ced4c832395f01753268eca23