### PR TITLE
Improve skill tree details panel

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -27,10 +27,10 @@ The arena contains a baseball bat that starts on the ground. It now appears usin
 Press **I** (or **E**) to open the 5x5 inventory grid. Keys are matched case-insensitively so holding Shift won't prevent the menus from toggling. Items stack up to 10 per slot. A five slot hotbar sits at the bottom of the screen for quick access and now appears on a dark background so it is easy to see. Newly picked up items fill the first empty hotbar slot before using inventory space. Drag to rearrange items or right click to move them to the hotbar. Quick move only works when a hotbar slot is free and does nothing on empty inventory slots. Clicking any inventory slot and then a hotbar slot (or vice versa) now swaps their contents even if one is empty. Use the number keys **1-5** to change the active slot. Both the inventory and crafting windows can be dragged by their top bars and will remember their last position when closed.
 Press **K** to open the skill tree and spend mutation points.
 The tree now highlights skills that are available to unlock. Clicking any node
-opens a panel describing the ability, its current level and the cost for the
-next upgrade. The upgrade button is disabled if you lack points so you can
-quickly see what to work toward without cluttering the screen with distant
-skills.
+opens a panel describing the ability and lists what each level does along with
+its cost. The panel also shows your current level and the cost for the next
+upgrade. The upgrade button is disabled if you lack points so you can quickly
+see what to work toward without cluttering the screen with distant skills.
 Inventory and hotbar slots now display the item icons found in the `assets` folder. If an icon is missing for an item, a `?` will appear instead.
 Hotbar items with an active cooldown display a gray, semi-transparent circle that recedes clockwise as the timer expires.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -255,6 +255,10 @@
               id="skillDesc"
               style="font-size: 12px; margin-bottom: 4px"
             ></div>
+            <ul
+              id="skillLevels"
+              style="font-size: 12px; margin-bottom: 4px; padding-left: 16px"
+            ></ul>
             <div id="skillLevel" style="margin-bottom: 4px"></div>
             <div id="skillCost" style="margin-bottom: 8px"></div>
             <button id="skillUpgrade">Unlock</button>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -74,6 +74,7 @@ const skillGrid = document.getElementById("skillGrid");
 const skillDetails = document.getElementById("skillDetails");
 const skillNameDiv = document.getElementById("skillName");
 const skillDescDiv = document.getElementById("skillDesc");
+const skillLevelsDiv = document.getElementById("skillLevels");
 const skillLevelDiv = document.getElementById("skillLevel");
 const skillCostDiv = document.getElementById("skillCost");
 const skillUpgradeBtn = document.getElementById("skillUpgrade");
@@ -506,6 +507,14 @@ function updateSkillDetails() {
     level < selectedSkill.max ? selectedSkill.costs[level + 1] : null;
   skillNameDiv.textContent = selectedSkill.name;
   skillDescDiv.textContent = selectedSkill.description;
+  skillLevelsDiv.innerHTML = "";
+  if (selectedSkill.levels) {
+    selectedSkill.levels.forEach((lv, idx) => {
+      const li = document.createElement("li");
+      li.textContent = `Lv ${idx + 1}: ${lv.effect} (Cost: ${lv.cost})`;
+      skillLevelsDiv.appendChild(li);
+    });
+  }
   skillLevelDiv.textContent = `Level ${level}/${selectedSkill.max}`;
   skillCostDiv.textContent = nextCost ? `Cost: ${nextCost}` : "Max level";
   skillUpgradeBtn.textContent = level === 0 ? "Unlock" : "Upgrade";

--- a/frontend/src/skill_tree.js
+++ b/frontend/src/skill_tree.js
@@ -57,6 +57,11 @@ export const SKILL_INFO = [
     levelKey: "fireOrbLevel",
     max: 3,
     costs: [0, 1, 2, 3],
+    levels: [
+      { effect: "1 orb circles player (base level)", cost: 1 },
+      { effect: "Adds a second orb", cost: 2 },
+      { effect: "Reduce orb respawn cooldown by 50%", cost: 3 },
+    ],
   },
   {
     id: "fireball_spell",
@@ -66,6 +71,11 @@ export const SKILL_INFO = [
     levelKey: "fireballLevel",
     max: 3,
     costs: [0, 2, 2, 3],
+    levels: [
+      { effect: "Moderate damage, small explosion", cost: 2 },
+      { effect: "Increased damage & explosion radius (+25%)", cost: 2 },
+      { effect: "Greatly increased radius (+50%), pierces 1 zombie", cost: 3 },
+    ],
   },
   {
     id: "phoenix_revival_skill",
@@ -75,6 +85,11 @@ export const SKILL_INFO = [
     levelKey: "phoenixRevivalLevel",
     max: 3,
     costs: [0, 4, 3, 4],
+    levels: [
+      { effect: "Revive at 10% HP, +25% dmg boost (5 sec)", cost: 4 },
+      { effect: "Revive at 30% HP, +35% dmg boost (8 sec)", cost: 3 },
+      { effect: "Revive at 50% HP, +50% dmg boost (12 sec)", cost: 4 },
+    ],
   },
 ];
 

--- a/frontend/tests/skill_tree.test.js
+++ b/frontend/tests/skill_tree.test.js
@@ -4,6 +4,7 @@ import {
   upgradeFireball,
   upgradeFireOrb,
   upgradePhoenixRevival,
+  SKILL_INFO,
 } from "../src/skill_tree.js";
 import { createPlayer, resetPlayerForNewGame } from "../src/player.js";
 import { createInventory } from "../src/inventory.js";
@@ -66,4 +67,15 @@ test("upgradePhoenixRevival costs", () => {
   assert(upgradePhoenixRevival(player));
   assert.strictEqual(player.abilities.phoenixRevivalLevel, 3);
   assert.strictEqual(player.fireMutationPoints, 0);
+});
+
+test("skill info includes level details", () => {
+  for (const info of SKILL_INFO) {
+    assert(Array.isArray(info.levels));
+    assert.strictEqual(info.levels.length, info.max);
+    info.levels.forEach((lvl, i) => {
+      assert.strictEqual(lvl.cost, info.costs[i + 1]);
+      assert(typeof lvl.effect === "string");
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add upgrade level info to `SKILL_INFO`
- show level effects in the skill tree details panel
- list level effects in the documentation
- test presence of upgrade descriptions

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_686c018393d08323b7db9d0a7699a510