### PR TITLE
Add breakable shelves and store layout

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -12,7 +12,11 @@ npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted. Grey wall segments are scattered around the level and block both you and the zombies. Zombies now reliably stop when they hit these walls instead of occasionally slipping through them. The fullscreen layout now uses about twenty segments instead of just four. If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
+The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted.
+
+Shelving now forms organized aisles built from steel, wood, and plastic segments. These shelves are breakable, with steel being the hardest to destroy and plastic the weakest. Damaged shelves flash and briefly show a health bar before collapsing. The layout generator spaces aisles widely so there is plenty of room to maneuver while still providing clear paths and chokepoints.
+
+If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
 
 The canvas now automatically resizes to fill the entire browser window so the action takes up all available space.
 

--- a/frontend/src/arrow.js
+++ b/frontend/src/arrow.js
@@ -3,6 +3,7 @@ export const ARROW_DAMAGE = 2;
 export const ARROW_PREVIEW_RANGE = 12 * 40;
 
 import { circleRectColliding, isColliding } from "./game_logic.js";
+import { damageWall } from "./walls.js";
 
 export function predictArrowEndpoint(x, y, direction, walls, zombies = []) {
   const len = Math.hypot(direction.x, direction.y);
@@ -40,9 +41,14 @@ export function updateArrows(arrows, zombies, walls, onKill = () => {}) {
     a.x += a.vx;
     a.y += a.vy;
     let remove = false;
-    if (walls.some((w) => circleRectColliding(a, w, 2))) {
-      remove = true;
-    } else {
+    for (const w of walls) {
+      if (circleRectColliding(a, w, 2)) {
+        damageWall(w, a.damage);
+        remove = true;
+        break;
+      }
+    }
+    if (!remove) {
       for (let j = zombies.length - 1; j >= 0; j--) {
         const z = zombies[j];
         if (isColliding(a, z, 2)) {

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -122,32 +122,6 @@ export const PLAYER_MAX_HEALTH = 10;
 export const SEGMENT_SIZE = 40;
 export const TRIGGER_DISTANCE = 60;
 
-export function generateWalls(width, height, count = 3) {
-  const walls = [];
-  const gridW = Math.floor(width / SEGMENT_SIZE);
-  const gridH = Math.floor(height / SEGMENT_SIZE);
-  for (let i = 0; i < count; i++) {
-    const pieces = 16 + Math.floor(Math.random() * 5); // 3-5
-    let gx = Math.floor(Math.random() * gridW);
-    let gy = Math.floor(Math.random() * gridH);
-    for (let p = 0; p < pieces; p++) {
-      walls.push({
-        x: gx * SEGMENT_SIZE,
-        y: gy * SEGMENT_SIZE,
-        size: SEGMENT_SIZE,
-      });
-      const dir = Math.random() < 0.5 ? "h" : "v";
-      if (dir === "h") {
-        gx += Math.random() < 0.5 ? -1 : 1;
-      } else {
-        gy += Math.random() < 0.5 ? -1 : 1;
-      }
-      gx = Math.max(0, Math.min(gridW - 1, gx));
-      gy = Math.max(0, Math.min(gridH - 1, gy));
-    }
-  }
-  return walls;
-}
 
 export function circleRectColliding(circle, rect, radius) {
   const closestX = Math.max(rect.x, Math.min(circle.x, rect.x + rect.size));

--- a/frontend/src/spells.js
+++ b/frontend/src/spells.js
@@ -20,6 +20,7 @@ export function fireballStats(level) {
 }
 
 import { circleRectColliding, isColliding } from "./game_logic.js";
+import { damageWall } from "./walls.js";
 export function createFireball(x, y, direction, level = 1, damageMult = 1) {
   const len = Math.hypot(direction.x, direction.y);
   if (len === 0) return null;
@@ -75,9 +76,16 @@ export function updateFireballs(
     let explode = false;
     if (fb.traveled >= FIREBALL_RANGE) {
       explode = true;
-    } else if (walls.some((w) => circleRectColliding(fb, w, 4))) {
-      explode = true;
     } else {
+      for (const w of walls) {
+        if (circleRectColliding(fb, w, 4)) {
+          damageWall(w, fb.damage);
+          explode = true;
+          break;
+        }
+      }
+    }
+    if (!explode) {
       for (let j = zombies.length - 1; j >= 0; j--) {
         const z = zombies[j];
         if (isColliding(fb, z, 4)) {
@@ -104,6 +112,14 @@ export function updateFireballs(
             zombies.splice(j, 1);
             onKill(z);
           }
+        }
+      }
+      for (const w of walls) {
+        if (
+          Math.hypot(w.x + w.size / 2 - fb.x, w.y + w.size / 2 - fb.y) <=
+          fb.radius
+        ) {
+          damageWall(w, fb.damage);
         }
       }
       if (explosions) {

--- a/frontend/src/walls.js
+++ b/frontend/src/walls.js
@@ -1,0 +1,130 @@
+import { SEGMENT_SIZE } from "./game_logic.js";
+
+export const WALL_MATERIALS = {
+  steel: { hp: 300, img: "assets/shelf_metal.png" },
+  wood: { hp: 150, img: "assets/shelf_wood.png" },
+  plastic: { hp: 75, img: "assets/shelf_plastic.png" },
+};
+
+export const WALL_IMAGES = {};
+if (typeof Image !== "undefined") {
+  for (const [mat, data] of Object.entries(WALL_MATERIALS)) {
+    const img = new Image();
+    img.src = data.img;
+    WALL_IMAGES[mat] = img;
+  }
+}
+
+export function createWall(gx, gy, material = "wood") {
+  const hp = WALL_MATERIALS[material].hp;
+  return {
+    x: gx * SEGMENT_SIZE,
+    y: gy * SEGMENT_SIZE,
+    size: SEGMENT_SIZE,
+    material,
+    hp,
+    maxHp: hp,
+    damageTimer: 0,
+  };
+}
+
+function randMaterial() {
+  const keys = Object.keys(WALL_MATERIALS);
+  return keys[Math.floor(Math.random() * keys.length)];
+}
+
+export function generateStoreWalls(width, height) {
+  const walls = [];
+  const gridW = Math.floor(width / SEGMENT_SIZE);
+  const gridH = Math.floor(height / SEGMENT_SIZE);
+
+  const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+  const addVertical = (gx, gy1, gy2) => {
+    gx = clamp(gx, 0, gridW - 1);
+    gy1 = clamp(gy1, 0, gridH - 1);
+    gy2 = clamp(gy2, 0, gridH - 1);
+    for (let y = gy1; y <= gy2; y++) {
+      walls.push(createWall(gx, y, randMaterial()));
+    }
+  };
+  const addHorizontal = (gy, gx1, gx2) => {
+    gy = clamp(gy, 0, gridH - 1);
+    gx1 = clamp(gx1, 0, gridW - 1);
+    gx2 = clamp(gx2, 0, gridW - 1);
+    for (let x = gx1; x <= gx2; x++) {
+      walls.push(createWall(x, gy, randMaterial()));
+    }
+  };
+
+  const addRoom = (x, y, w, h) => {
+    for (let gx = x; gx < x + w; gx++) {
+      for (let gy = y; gy < y + h; gy++) {
+        if (gx === x + Math.floor(w / 2) && gy === y + h - 1) {
+          continue; // entrance
+        }
+        if (gx === x || gx === x + w - 1 || gy === y || gy === y + h - 1) {
+          walls.push(createWall(gx, gy, randMaterial()));
+        }
+      }
+    }
+  };
+
+  // vertical aisle positions spaced widely
+  const vSpacing = Math.max(6, Math.floor(gridW / 4));
+  const vPositions = [];
+  for (let gx = 2; gx < gridW - 2; gx += vSpacing) {
+    vPositions.push(gx);
+    let y = 2;
+    while (y < gridH - 4) {
+      const len = 4 + Math.floor(Math.random() * 3); // 4-6 segments
+      addVertical(gx, y, Math.min(y + len - 1, gridH - 4));
+      y += len + 3 + Math.floor(Math.random() * 2); // gap 3-4
+    }
+  }
+
+  // horizontal aisles with generous gaps
+  const hSpacing = Math.max(8, Math.floor(gridH / 5));
+  for (let gy = 4; gy < gridH - 3; gy += hSpacing) {
+    let x = 2;
+    while (x < gridW - 4) {
+      const len = 4 + Math.floor(Math.random() * 3);
+      addHorizontal(gy, x, Math.min(x + len - 1, gridW - 4));
+      x += len + 4 + Math.floor(Math.random() * 3); // gap 4-6
+    }
+  }
+
+  // occasional U-shaped sections
+  vPositions.forEach((gx) => {
+    if (Math.random() < 0.4) {
+      const y = 2 + Math.floor(Math.random() * Math.max(1, gridH - 8));
+      addHorizontal(y, gx - 1, gx + 1);
+      addHorizontal(y + 1, gx - 1, gx + 1);
+    }
+  });
+
+  // one or two enclosed rooms
+  const roomCount = 1 + Math.floor(Math.random() * 2);
+  for (let r = 0; r < roomCount; r++) {
+    const rw = Math.min(3 + Math.floor(Math.random() * 3), gridW - 2);
+    const rh = Math.min(3 + Math.floor(Math.random() * 3), gridH - 2);
+    if (rw < 3 || rh < 3) continue;
+    const startX = 1 + Math.floor(Math.random() * (gridW - rw - 1));
+    const startY = 1 + Math.floor(Math.random() * (gridH - rh - 1));
+    addRoom(startX, startY, rw, rh);
+  }
+
+  return walls;
+}
+
+export function damageWall(wall, dmg) {
+  wall.hp -= dmg;
+  wall.damageTimer = 5;
+}
+
+export function updateWalls(walls) {
+  for (let i = walls.length - 1; i >= 0; i--) {
+    const w = walls[i];
+    if (w.damageTimer > 0) w.damageTimer--;
+    if (w.hp <= 0) walls.splice(i, 1);
+  }
+}

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -4,7 +4,6 @@ import {
   createZombie,
   moveTowards,
   isColliding,
-  generateWalls,
   circleRectColliding,
   SEGMENT_SIZE,
   TRIGGER_DISTANCE,
@@ -20,6 +19,7 @@ import {
   createContainer,
   spawnContainers,
 } from "../src/game_logic.js";
+import { generateStoreWalls } from "../src/walls.js";
 
 test("moveTowards moves entity toward target", () => {
   const zombie = { x: 0, y: 0 };
@@ -37,12 +37,12 @@ test("isColliding detects overlap", () => {
   assert.strictEqual(isColliding(a, c, 3), false);
 });
 
-test("generateWalls creates segments within bounds", () => {
-  const walls = generateWalls(100, 100, 1);
+test("generateStoreWalls creates segments within bounds", () => {
+  const walls = generateStoreWalls(200, 200);
   assert(walls.length > 0);
   walls.forEach((w) => {
-    assert(w.x >= 0 && w.x + w.size <= 100);
-    assert(w.y >= 0 && w.y + w.size <= 100);
+    assert(w.x >= 0 && w.x + w.size <= 200);
+    assert(w.y >= 0 && w.y + w.size <= 200);
     assert.strictEqual(w.size, SEGMENT_SIZE);
   });
 });

--- a/frontend/tests/walls.test.js
+++ b/frontend/tests/walls.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createWall,
+  generateStoreWalls,
+  WALL_MATERIALS,
+} from "../src/walls.js";
+import { SEGMENT_SIZE } from "../src/game_logic.js";
+
+test("createWall sets hp based on material", () => {
+  const w = createWall(0, 0, "steel");
+  assert.strictEqual(w.hp, WALL_MATERIALS.steel.hp);
+  assert.strictEqual(w.size, SEGMENT_SIZE);
+});
+
+test("generateStoreWalls returns walls with materials", () => {
+  const walls = generateStoreWalls(200, 200);
+  assert(walls.length > 0);
+  walls.forEach((w) => {
+    assert.ok(WALL_MATERIALS[w.material]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `walls.js` module with breakable wall logic and layout generator
- draw shelves using material sprites and show health bars
- refactor game reset to use structured wall generation
- damage walls with weapons, arrows and fireballs
- update docs with new breakable wall info
- add unit tests for wall generation
- adjust store layout generation

## Testing
- `npx prettier -w frontend/src/walls.js docs/zombie_game.md`
- `npm test --prefix frontend`
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c0f4397d08323af529538585c9712