### PR TITLE
Fix wall destruction logic

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -15,6 +15,7 @@ npm run dev
 The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted.
 
 Shelving now forms organized aisles built from steel, wood, and plastic segments. These shelves are breakable, with steel being the hardest to destroy and plastic the weakest. Damaged shelves flash and briefly show a health bar before collapsing. The layout generator spaces aisles widely so there is plenty of room to maneuver while still providing clear paths and chokepoints.
+Use crafted tools like the **Hammer**, **Crowbar**, or **Axe** to chip away at shelves. Each hit lowers their health and once it reaches zero the shelf disappears, dropping building materials.
 
 If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
 

--- a/frontend/src/walls.js
+++ b/frontend/src/walls.js
@@ -119,6 +119,7 @@ export function generateStoreWalls(width, height) {
 export function damageWall(wall, dmg) {
   wall.hp -= dmg;
   wall.damageTimer = 5;
+  return wall.hp <= 0;
 }
 
 export function updateWalls(walls) {

--- a/frontend/tests/walls.test.js
+++ b/frontend/tests/walls.test.js
@@ -4,6 +4,8 @@ import {
   createWall,
   generateStoreWalls,
   WALL_MATERIALS,
+  damageWall,
+  updateWalls,
 } from "../src/walls.js";
 import { SEGMENT_SIZE } from "../src/game_logic.js";
 
@@ -19,4 +21,22 @@ test("generateStoreWalls returns walls with materials", () => {
   walls.forEach((w) => {
     assert.ok(WALL_MATERIALS[w.material]);
   });
+});
+
+test("damageWall returns true when a wall breaks", () => {
+  const w = createWall(0, 0, "plastic");
+  const destroyed = damageWall(w, WALL_MATERIALS.plastic.hp);
+  assert.strictEqual(destroyed, true);
+  const arr = [w];
+  updateWalls(arr);
+  assert.strictEqual(arr.length, 0);
+});
+
+test("damageWall returns false when a wall survives", () => {
+  const w = createWall(0, 0, "wood");
+  const destroyed = damageWall(w, 1);
+  assert.strictEqual(destroyed, false);
+  const arr = [w];
+  updateWalls(arr);
+  assert.strictEqual(arr.length, 1);
 });


### PR DESCRIPTION
## Summary
- return boolean from `damageWall` to detect breakage
- add unit tests for wall damage
- document how shelves can be broken in the zombie game guide

## Testing
- `npm test --silent --prefix frontend`
- `pytest -q backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_686c860847dc83238699c79792634433