### PR TITLE
Improve phoenix revival skill

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -92,16 +92,17 @@ delay. Additional points add a second orb and shorten the respawn time.
 ## Phoenix Revival Passive
 
 This ultimate skill costs **4 Fire Mutation Points** to unlock. If you would die
-with the ability ready, you instead revive with a portion of your health and a
-temporary damage boost. The skill then goes on cooldown for two minutes. The
-revival check happens whenever your HP reaches zero, regardless of what caused
-the damage.
+with the ability ready, you instead revive with **1 health** and a temporary
+damage boost. Nearby zombies are knocked away when this happens, giving you a
+moment to escape. The skill then goes on cooldown for two minutes. The revival
+check happens whenever your HP reaches zero, regardless of what caused the
+damage.
 
-| Level | Revive Health | Damage Buff | Duration | Cost |
-| ----- | ------------- | ----------- | -------- | ---- |
-| **1** | 10% HP        | +25%        | 5s       | 4    |
-| **2** | 30% HP        | +35%        | 8s       | 3    |
-| **3** | 50% HP        | +50%        | 12s      | 4    |
+| Level | Damage Buff | Duration | Cost |
+| ----- | ----------- | -------- | ---- |
+| **1** | +25%        | 5s       | 4    |
+| **2** | +35%        | 8s       | 3    |
+| **3** | +50%        | 12s      | 4    |
 
 ## Bow and Arrow
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -717,7 +717,7 @@ function update() {
   }
 
   if (player.health <= 0) {
-    if (!tryPhoenixRevival(player, PLAYER_MAX_HEALTH)) {
+    if (!tryPhoenixRevival(player, PLAYER_MAX_HEALTH, zombies)) {
       gameOver = true;
       gameOverDiv.style.display = "block";
       return;
@@ -978,7 +978,7 @@ function update() {
       player.damageCooldown = 30;
       z.attackCooldown = 30;
       if (player.health <= 0) {
-        if (!tryPhoenixRevival(player, PLAYER_MAX_HEALTH)) {
+        if (!tryPhoenixRevival(player, PLAYER_MAX_HEALTH, zombies)) {
           gameOver = true;
           gameOverDiv.style.display = "block";
         }

--- a/frontend/src/player.js
+++ b/frontend/src/player.js
@@ -1,3 +1,8 @@
+import { attackZombies } from "./game_logic.js";
+
+export const PHOENIX_KNOCKBACK_RADIUS = 40;
+export const PHOENIX_KNOCKBACK_FORCE = 20;
+
 export function createPlayer(PLAYER_MAX_HEALTH) {
   return {
     x: 0,
@@ -40,20 +45,28 @@ export function resetPlayerForNewGame(player, PLAYER_MAX_HEALTH) {
   player.fireMutationPoints = 0;
 }
 
-export function tryPhoenixRevival(player, PLAYER_MAX_HEALTH) {
+export function tryPhoenixRevival(player, PLAYER_MAX_HEALTH, zombies = []) {
   if (
     player.abilities.phoenixRevival &&
     player.phoenixCooldown <= 0 &&
     player.health <= 0
   ) {
     const lvl = player.abilities.phoenixRevivalLevel;
-    const hpPerc = [0, 0.1, 0.3, 0.5][lvl];
     const dmg = [0, 1.25, 1.35, 1.5][lvl];
     const dur = [0, 300, 480, 720][lvl];
-    player.health = Math.max(1, Math.round(PLAYER_MAX_HEALTH * hpPerc));
+    player.health = 1;
     player.phoenixCooldown = 7200;
     player.damageBuffMult = dmg;
     player.damageBuffTimer = dur;
+    attackZombies(
+      player,
+      zombies,
+      0,
+      PHOENIX_KNOCKBACK_RADIUS,
+      null,
+      Math.PI * 2,
+      PHOENIX_KNOCKBACK_FORCE,
+    );
     return true;
   }
   return false;

--- a/frontend/tests/phoenix.test.js
+++ b/frontend/tests/phoenix.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createPlayer, tryPhoenixRevival } from "../src/player.js";
-import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
+import { PLAYER_MAX_HEALTH, createZombie } from "../src/game_logic.js";
 
 test("tryPhoenixRevival revives player", () => {
   const player = createPlayer(PLAYER_MAX_HEALTH);
@@ -15,6 +15,20 @@ test("tryPhoenixRevival revives player", () => {
   assert.strictEqual(player.phoenixCooldown, 7200);
   assert.strictEqual(player.damageBuffMult, 1.25);
   assert.strictEqual(player.damageBuffTimer, 300);
+});
+
+test("tryPhoenixRevival knocks back nearby zombies", () => {
+  const player = createPlayer(PLAYER_MAX_HEALTH);
+  player.abilities.phoenixRevival = true;
+  player.abilities.phoenixRevivalLevel = 1;
+  player.phoenixCooldown = 0;
+  player.health = 0;
+  player.x = 0;
+  player.y = 0;
+  const zombie = createZombie(10, 0);
+  const res = tryPhoenixRevival(player, PLAYER_MAX_HEALTH, [zombie]);
+  assert.strictEqual(res, true);
+  assert(zombie.x > 10);
 });
 
 test("tryPhoenixRevival fails when on cooldown", () => {


### PR DESCRIPTION
## Summary
- enhance phoenix revival skill by always reviving with 1 HP and knocking back nearby enemies
- update game logic to pass zombies into the revival check
- document the new behaviour in the zombie game guide
- add unit test covering knockback on revival

## Testing
- `npm test --prefix frontend`
- `pytest -q backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_686c8c0ae8cc8323ad8c3bddb14cbe05