### PR TITLE
Fix melee shelf collision detection

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -16,6 +16,7 @@ The game runs entirely in the browser. Open `http://localhost:3000` and you will
 
 Shelving now forms organized aisles built from steel, wood, and plastic segments. These shelves are breakable, with steel being the hardest to destroy and plastic the weakest. Damaged shelves flash and briefly show a health bar before collapsing. The layout generator spaces aisles widely so there is plenty of room to maneuver while still providing clear paths and chokepoints.
 Use crafted tools like the **Hammer**, **Crowbar**, or **Axe** to chip away at shelves. Melee swings now deal more damage so only a handful are needed to break a shelf. Once its health reaches zero the shelf disappears, dropping building materials.
+Collision detection for melee swings uses the closest point on the shelf, so striking from the side reliably damages it.
 
 If a zombie touches you, the game ends and a **New Game** button appears so you can immediately play again.
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -20,6 +20,7 @@ import {
   WALL_IMAGES,
   damageWall,
   updateWalls,
+  wallSwingHit,
 } from "./walls.js";
 import {
   createPlayer,
@@ -912,14 +913,8 @@ function update() {
       5,
     );
     const dir = { x: player.facing.x, y: player.facing.y };
-    const len = Math.hypot(dir.x, dir.y);
-    const norm = len > 0 ? { x: dir.x / len, y: dir.y / len } : null;
-    const cosHalf = Math.cos(Math.PI / 4);
     walls.forEach((w) => {
-      const wx = w.x + SEGMENT_SIZE / 2 - player.x;
-      const wy = w.y + SEGMENT_SIZE / 2 - player.y;
-      const dist = Math.hypot(wx, wy);
-      if (dist <= 30 && norm && wx * norm.x + wy * norm.y >= cosHalf * dist) {
+      if (wallSwingHit(player, w, 30, dir, Math.PI / 2)) {
         const allowed =
           {
             hammer: ["plastic"],

--- a/frontend/src/walls.js
+++ b/frontend/src/walls.js
@@ -123,6 +123,25 @@ export function damageWall(wall, dmg) {
   return wall.hp <= 0;
 }
 
+export function wallSwingHit(
+  player,
+  wall,
+  range,
+  direction,
+  arc = Math.PI / 2,
+) {
+  const len = Math.hypot(direction.x, direction.y);
+  if (len === 0) return false;
+  const dirNorm = { x: direction.x / len, y: direction.y / len };
+  const cosHalf = Math.cos(arc / 2);
+  const closestX = Math.max(wall.x, Math.min(player.x, wall.x + wall.size));
+  const closestY = Math.max(wall.y, Math.min(player.y, wall.y + wall.size));
+  const wx = closestX - player.x;
+  const wy = closestY - player.y;
+  const dist = Math.hypot(wx, wy);
+  return dist <= range && wx * dirNorm.x + wy * dirNorm.y >= cosHalf * dist;
+}
+
 export function updateWalls(walls) {
   for (let i = walls.length - 1; i >= 0; i--) {
     const w = walls[i];

--- a/frontend/tests/walls.test.js
+++ b/frontend/tests/walls.test.js
@@ -6,6 +6,7 @@ import {
   WALL_MATERIALS,
   damageWall,
   updateWalls,
+  wallSwingHit,
 } from "../src/walls.js";
 import { SEGMENT_SIZE } from "../src/game_logic.js";
 
@@ -52,4 +53,11 @@ test("axe breaks wood wall in a few swings", () => {
   const arr = [w];
   updateWalls(arr);
   assert.strictEqual(arr.length, 0);
+});
+
+test("wallSwingHit detects melee contact at wall edge", () => {
+  const wall = createWall(0, 0, "wood");
+  const player = { x: SEGMENT_SIZE + 10, y: SEGMENT_SIZE / 2 };
+  const dir = { x: -1, y: 0 };
+  assert.strictEqual(wallSwingHit(player, wall, 30, dir, Math.PI / 2), true);
 });


### PR DESCRIPTION
## Summary
- correct melee range check on shelves using closest point logic
- expose `wallSwingHit` helper and use it in the update loop
- document improved melee collision detection
- test new `wallSwingHit` helper

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_686c8d74fdd88323984fc6d6ebd2a7f5