### PR TITLE
Fix wood barricade icon in crafting menu

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -117,4 +117,4 @@ Equip the Bow in your hotbar. Hold the right mouse button or **Space** to aim, t
 1. Loot cardboard boxes for Scrap Metal, Duct Tape and Nails.
 2. Combine these to craft a Hammer, Crowbar or Axe.
 3. Use those tools to destroy shelves and gather Plastic Fragments, Wood Planks and Steel Plates.
-4. Craft advanced gear like Baseball Bats, Bows, Reinforced Axes and Barricades using the harvested materials.
+4. Craft advanced gear like Baseball Bats, Bows, Reinforced Axes and Wood Barricades using the harvested materials.

--- a/frontend/src/crafting.js
+++ b/frontend/src/crafting.js
@@ -67,8 +67,8 @@ export const RECIPES = [
     ingredients: { steel_plates: 3, wood_planks: 2 },
   },
   {
-    id: "barricade",
-    title: "Barricade",
+    id: "wood_barricade",
+    title: "Wood Barricade",
     description: "Blocks zombies when placed.",
     ingredients: { wood_planks: 2, nails: 4 },
   },

--- a/frontend/tests/crafting.test.js
+++ b/frontend/tests/crafting.test.js
@@ -42,3 +42,16 @@ test("craft hammer recipe", () => {
     .some((s) => s.item === "hammer");
   assert.strictEqual(hasHammer, true);
 });
+
+test("craft wood barricade", () => {
+  const inv = createInventory();
+  addItem(inv, "wood_planks", 2);
+  addItem(inv, "nails", 4);
+  const recipe = RECIPES.find((r) => r.id === "wood_barricade");
+  const success = craftRecipe(inv, recipe);
+  assert.strictEqual(success, true);
+  const hasItem = inv.slots
+    .concat(inv.hotbar)
+    .some((s) => s.item === "wood_barricade");
+  assert.strictEqual(hasItem, true);
+});


### PR DESCRIPTION
## Summary
- use `wood_barricade` id in crafting recipes
- mention Wood Barricades in docs
- test that Wood Barricades can be crafted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c8edcc96483238e02c0acbe8a9f9c