### PR TITLE
Buff phoenix revival knockback

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -94,8 +94,8 @@ delay. Additional points add a second orb and shorten the respawn time.
 
 This ultimate skill costs **4 Fire Mutation Points** to unlock. If you would die
 with the ability ready, you instead revive with **1 health** and a temporary
-damage boost. Nearby zombies are knocked away when this happens, giving you a
-moment to escape. The skill then goes on cooldown for two minutes. The revival
+damage boost. Nearby zombies are knocked away with much greater force when this
+happens, giving you a moment to escape. The skill then goes on cooldown for two minutes. The revival
 check happens whenever your HP reaches zero, regardless of what caused the
 damage.
 

--- a/frontend/src/player.js
+++ b/frontend/src/player.js
@@ -1,7 +1,8 @@
 import { attackZombies } from "./game_logic.js";
 
 export const PHOENIX_KNOCKBACK_RADIUS = 40;
-export const PHOENIX_KNOCKBACK_FORCE = 20;
+// Increased so the revival blast sends zombies much farther away
+export const PHOENIX_KNOCKBACK_FORCE = 60;
 
 export function createPlayer(PLAYER_MAX_HEALTH) {
   return {

--- a/frontend/tests/phoenix.test.js
+++ b/frontend/tests/phoenix.test.js
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createPlayer, tryPhoenixRevival } from "../src/player.js";
+import {
+  createPlayer,
+  tryPhoenixRevival,
+  PHOENIX_KNOCKBACK_FORCE,
+} from "../src/player.js";
 import { PLAYER_MAX_HEALTH, createZombie } from "../src/game_logic.js";
 
 test("tryPhoenixRevival revives player", () => {
@@ -28,7 +32,7 @@ test("tryPhoenixRevival knocks back nearby zombies", () => {
   const zombie = createZombie(10, 0);
   const res = tryPhoenixRevival(player, PLAYER_MAX_HEALTH, [zombie]);
   assert.strictEqual(res, true);
-  assert(zombie.x > 10);
+  assert(zombie.x >= 10 + PHOENIX_KNOCKBACK_FORCE);
 });
 
 test("tryPhoenixRevival fails when on cooldown", () => {


### PR DESCRIPTION
## Summary
- increase knockback force of Phoenix Revival and document the change
- adjust the Phoenix Revival test to expect the stronger knockback

## Testing
- `npm test --prefix frontend`
- `pytest -q backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_686c92e42370832387ed4bb7a6e21c8f