### PR TITLE
Improve zombie pathing with collision blocking

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -13,6 +13,7 @@ npm run dev
 ```
 
 The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. A new zombie steps through this door every 3–5 seconds. They roam toward random destinations so they naturally spread out but will pursue the player once spotted.
+Zombies now treat each other as obstacles, so only one can occupy a grid space at a time and new zombies won't spawn on top of existing ones.
 
 Shelving now forms organized aisles built from steel, wood, and plastic segments. These shelves are breakable, with steel being the hardest to destroy and plastic the weakest. Damaged shelves flash and briefly show a health bar before collapsing. The layout generator spaces aisles widely so there is plenty of room to maneuver while still providing clear paths and chokepoints.
 Use crafted tools like the **Hammer**, **Crowbar**, or **Axe** to chip away at shelves. Melee swings now deal more damage so only a handful are needed to break a shelf. Once its health reaches zero the shelf disappears, dropping building materials.

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -141,7 +141,7 @@ export function circleRectColliding(circle, rect, radius) {
   return dx * dx + dy * dy < radius * radius;
 }
 
-export function findPath(start, goal, walls, width, height) {
+export function findPath(start, goal, walls, width, height, blockers = []) {
   const gridW = Math.floor(width / SEGMENT_SIZE);
   const gridH = Math.floor(height / SEGMENT_SIZE);
   const sx = Math.floor(start.x / SEGMENT_SIZE);
@@ -151,6 +151,12 @@ export function findPath(start, goal, walls, width, height) {
   const blocked = new Set(
     walls.map((w) => `${w.x / SEGMENT_SIZE},${w.y / SEGMENT_SIZE}`),
   );
+  for (const b of blockers) {
+    const bx = Math.floor(b.x / SEGMENT_SIZE);
+    const by = Math.floor(b.y / SEGMENT_SIZE);
+    if (bx === sx && by === sy) continue;
+    blocked.add(`${bx},${by}`);
+  }
   const queue = [[sx, sy]];
   const key = (x, y) => `${x},${y}`;
   const cameFrom = new Map([[key(sx, sy), null]]);
@@ -213,7 +219,14 @@ export function hasLineOfSight(start, end, walls, radius = 0) {
   return !walls.some((w) => lineIntersectsRect(start, end, w, radius));
 }
 
-export function wanderZombie(zombie, walls, width, height, speed = 0.2) {
+export function wanderZombie(
+  zombie,
+  walls,
+  width,
+  height,
+  speed = 0.2,
+  zombies = [],
+) {
   if (zombie.idleTimer > 0) {
     zombie.idleTimer--;
     return;
@@ -230,49 +243,15 @@ export function wanderZombie(zombie, walls, width, height, speed = 0.2) {
     return;
   }
 
-  const path = findPath(zombie, zombie.dest, walls, width, height);
+  const path = findPath(zombie, zombie.dest, walls, width, height, zombies);
   if (path.length < 2) {
+    const prevX = zombie.x;
+    const prevY = zombie.y;
     moveTowards(zombie, zombie.dest, speed);
-    return;
-  }
-
-  const [nx, ny] = path[1];
-  const target = {
-    x: nx * SEGMENT_SIZE + SEGMENT_SIZE / 2,
-    y: ny * SEGMENT_SIZE + SEGMENT_SIZE / 2,
-  };
-  moveTowards(zombie, target, speed);
-}
-
-export function moveZombie(zombie, player, walls, speed, width, height) {
-  const dist = Math.hypot(player.x - zombie.x, player.y - zombie.y);
-  if (!zombie.triggered) {
-    if (dist <= TRIGGER_DISTANCE && hasLineOfSight(zombie, player, walls, 10)) {
-      zombie.triggered = true;
-    } else {
-      wanderZombie(zombie, walls, width, height);
-      return;
-    }
-  }
-
-  if (hasLineOfSight(zombie, player, walls, 10)) {
-    const prevX = zombie.x;
-    const prevY = zombie.y;
-    moveTowards(zombie, player, speed);
-    if (walls.some((w) => circleRectColliding(zombie, w, 10))) {
-      zombie.x = prevX;
-      zombie.y = prevY;
-    }
-    return;
-  }
-
-  const path = findPath(zombie, player, walls, width, height);
-  if (path.length < 2) {
-    // Fallback to direct movement when no path is found
-    const prevX = zombie.x;
-    const prevY = zombie.y;
-    moveTowards(zombie, player, speed);
-    if (walls.some((w) => circleRectColliding(zombie, w, 10))) {
+    if (
+      walls.some((w) => circleRectColliding(zombie, w, 10)) ||
+      zombies.some((z) => z !== zombie && isColliding(zombie, z, 10))
+    ) {
       zombie.x = prevX;
       zombie.y = prevY;
     }
@@ -287,7 +266,76 @@ export function moveZombie(zombie, player, walls, speed, width, height) {
   const prevX = zombie.x;
   const prevY = zombie.y;
   moveTowards(zombie, target, speed);
-  if (walls.some((w) => circleRectColliding(zombie, w, 10))) {
+  if (
+    walls.some((w) => circleRectColliding(zombie, w, 10)) ||
+    zombies.some((z) => z !== zombie && isColliding(zombie, z, 10))
+  ) {
+    zombie.x = prevX;
+    zombie.y = prevY;
+  }
+}
+
+export function moveZombie(
+  zombie,
+  player,
+  walls,
+  speed,
+  width,
+  height,
+  zombies = [],
+) {
+  const dist = Math.hypot(player.x - zombie.x, player.y - zombie.y);
+  if (!zombie.triggered) {
+    if (dist <= TRIGGER_DISTANCE && hasLineOfSight(zombie, player, walls, 10)) {
+      zombie.triggered = true;
+    } else {
+      wanderZombie(zombie, walls, width, height, 0.2, zombies);
+      return;
+    }
+  }
+
+  if (hasLineOfSight(zombie, player, walls, 10)) {
+    const prevX = zombie.x;
+    const prevY = zombie.y;
+    moveTowards(zombie, player, speed);
+    if (
+      walls.some((w) => circleRectColliding(zombie, w, 10)) ||
+      zombies.some((z) => z !== zombie && isColliding(zombie, z, 10))
+    ) {
+      zombie.x = prevX;
+      zombie.y = prevY;
+    }
+    return;
+  }
+
+  const path = findPath(zombie, player, walls, width, height, zombies);
+  if (path.length < 2) {
+    // Fallback to direct movement when no path is found
+    const prevX = zombie.x;
+    const prevY = zombie.y;
+    moveTowards(zombie, player, speed);
+    if (
+      walls.some((w) => circleRectColliding(zombie, w, 10)) ||
+      zombies.some((z) => z !== zombie && isColliding(zombie, z, 10))
+    ) {
+      zombie.x = prevX;
+      zombie.y = prevY;
+    }
+    return;
+  }
+
+  const [nx, ny] = path[1];
+  const target = {
+    x: nx * SEGMENT_SIZE + SEGMENT_SIZE / 2,
+    y: ny * SEGMENT_SIZE + SEGMENT_SIZE / 2,
+  };
+  const prevX = zombie.x;
+  const prevY = zombie.y;
+  moveTowards(zombie, target, speed);
+  if (
+    walls.some((w) => circleRectColliding(zombie, w, 10)) ||
+    zombies.some((z) => z !== zombie && isColliding(zombie, z, 10))
+  ) {
     zombie.x = prevX;
     zombie.y = prevY;
   }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -955,14 +955,24 @@ function update() {
   }
 
   if (spawnTimer <= 0) {
-    zombies.push(spawnZombieAtDoor(spawnDoor));
+    const candidate = spawnZombieAtDoor(spawnDoor);
+    const cellX = Math.floor(candidate.x / SEGMENT_SIZE);
+    const cellY = Math.floor(candidate.y / SEGMENT_SIZE);
+    const occupied = zombies.some(
+      (z) =>
+        Math.floor(z.x / SEGMENT_SIZE) === cellX &&
+        Math.floor(z.y / SEGMENT_SIZE) === cellY,
+    );
+    if (!occupied) {
+      zombies.push(candidate);
+    }
     spawnTimer = 180 + Math.random() * 120;
   } else {
     spawnTimer--;
   }
 
   zombies.forEach((z) => {
-    moveZombie(z, player, walls, 1, canvas.width, canvas.height);
+    moveZombie(z, player, walls, 1, canvas.width, canvas.height, zombies);
     if (z.attackCooldown > 0) z.attackCooldown--;
     if (
       isColliding(z, player, 10) &&

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -85,6 +85,17 @@ test("findPath navigates around walls", () => {
   });
 });
 
+test("findPath treats zombies as blocked spaces", () => {
+  const start = { x: 10, y: 10 };
+  const end = { x: 90, y: 10 };
+  const zombieBlock = { x: 50, y: 10 };
+  const path = findPath(start, end, [], 120, 80, [zombieBlock]);
+  assert(path.length > 0);
+  const blockedCell = `${Math.floor(zombieBlock.x / SEGMENT_SIZE)},${Math.floor(zombieBlock.y / SEGMENT_SIZE)}`;
+  const cells = path.map((c) => `${c[0]},${c[1]}`);
+  assert.strictEqual(cells.includes(blockedCell), false);
+});
+
 test("hasLineOfSight detects blockage", () => {
   const wall = { x: 40, y: 0, size: SEGMENT_SIZE };
   const start = { x: 10, y: 10 };
@@ -147,6 +158,17 @@ test("moveZombie follows grid path when blocked", () => {
   // First path step keeps x ~20 but increases y toward open space
   assert(Math.abs(zombie.x - 20) < 1e-6);
   assert(zombie.y > 20);
+});
+
+test("moveZombie avoids occupied tiles", () => {
+  const zombieA = createZombie(10, 10);
+  zombieA.triggered = true;
+  const zombieB = createZombie(50, 10);
+  const player = { x: 90, y: 10 };
+  for (let i = 0; i < 50; i++) {
+    moveZombie(zombieA, player, [], 1, 120, 80, [zombieA, zombieB]);
+  }
+  assert.strictEqual(isColliding(zombieA, zombieB, 10), false);
 });
 
 test("attackZombies damages and removes zombies", () => {


### PR DESCRIPTION
## Summary
- prevent zombies from occupying the same grid tile
- avoid spawning a new zombie on an occupied tile
- update pathfinding logic to treat zombies as obstacles
- add unit tests for new behaviour
- document that zombies block each other

## Testing
- `npx prettier -w frontend/src/game_logic.js frontend/src/main.js frontend/tests/game_logic.test.js`
- `npx prettier -w docs/zombie_game.md`
- `black backend`
- `cd frontend && npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de9445f2883239c5412804b7b77dd