### PR TITLE
Add shelf looting feature

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -54,6 +54,8 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 
 Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box now contains **Scrap Metal**, **Duct Tape**, **Nails**, or a **Medkit** with equal probability. If there is room in your hotbar or inventory the item is added automatically. Otherwise a brief "Inventory Full" message appears. Opened boxes appear faded so you know they have been searched.
 
+Shelves can now be searched the same way. Hold **F** while standing near a shelf segment to rummage through it. Searching takes time and each shelf can only be looted once. Looted shelves fade just like opened boxes. Shelves usually contain nothing, but occasionally you might find any random item tucked away.
+
 Equip a Medkit and press the **Space** key or left mouse button to restore up to 3 health without exceeding your maximum.
 
 ## Fire Zombies

--- a/frontend/src/items.js
+++ b/frontend/src/items.js
@@ -1,5 +1,37 @@
 export const CONSUMABLE_ITEMS = new Set(["medkit", "mutation_serum_fire"]);
 
+export const ITEM_ICONS = {
+  core: "assets/zombie_core.png",
+  flesh: "assets/zombie_flesh.png",
+  teeth: "assets/zombie_teeth.png",
+  zombie_essence: "assets/zombie_essence.png",
+  elemental_potion: "assets/elemental_potion.png",
+  transformation_syringe: "assets/transformation_syringe.png",
+  fire_core: "assets/fire_core.png",
+  mutation_serum_fire: "assets/mutation_serum_fire.png",
+  fireball_spell: "assets/skill_fireball.png",
+  fire_orb_skill: "assets/skill_fire_orb.png",
+  phoenix_revival_skill: "assets/skill_phoenix_revival.png",
+  baseball_bat: "assets/baseball_bat.png",
+  medkit: "assets/medkit.png",
+  wood: "assets/wood.png",
+  bow: "assets/wooden_bow.png",
+  arrow: "assets/wooden_arrow.png",
+  scrap_metal: "assets/scrap_metal.png",
+  duct_tape: "assets/duct_tape.png",
+  nails: "assets/nails.png",
+  plastic_fragments: "assets/plastic_fragments.png",
+  wood_planks: "assets/wood_planks.png",
+  steel_plates: "assets/steel_plates.png",
+  hammer: "assets/hammer.png",
+  crowbar: "assets/crowbar.png",
+  axe: "assets/axe.png",
+  reinforced_axe: "assets/reinforced_axe.png",
+  wood_barricade: "assets/wood_barricade.png",
+};
+
+export const ITEM_IDS = Object.keys(ITEM_ICONS);
+
 import { PLAYER_MAX_HEALTH } from "./game_logic.js";
 
 export function applyConsumableEffect(player, itemId) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -21,6 +21,7 @@ import {
   damageWall,
   updateWalls,
   wallSwingHit,
+  openShelf,
 } from "./walls.js";
 import {
   createPlayer,
@@ -55,7 +56,12 @@ import { SKILL_INFO, SKILL_UPGRADERS } from "./skill_tree.js";
 import { createOrbs, updateOrbs } from "./orbs.js";
 import { makeDraggable } from "./ui.js";
 
-import { applyConsumableEffect, CONSUMABLE_ITEMS } from "./items.js";
+import {
+  applyConsumableEffect,
+  CONSUMABLE_ITEMS,
+  ITEM_ICONS,
+  ITEM_IDS,
+} from "./items.js";
 import { getItemCooldown } from "./cooldowns.js";
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
@@ -89,37 +95,7 @@ const skillLevelDiv = document.getElementById("skillLevel");
 const skillCostDiv = document.getElementById("skillCost");
 const skillUpgradeBtn = document.getElementById("skillUpgrade");
 
-// Mapping from item ids to icon paths. If an item is missing, a
-// question mark will be shown instead of an image.
-const ITEM_ICONS = {
-  core: "assets/zombie_core.png",
-  flesh: "assets/zombie_flesh.png",
-  teeth: "assets/zombie_teeth.png",
-  zombie_essence: "assets/zombie_essence.png",
-  elemental_potion: "assets/elemental_potion.png",
-  transformation_syringe: "assets/transformation_syringe.png",
-  fire_core: "assets/fire_core.png",
-  mutation_serum_fire: "assets/mutation_serum_fire.png",
-  fireball_spell: "assets/skill_fireball.png",
-  fire_orb_skill: "assets/skill_fire_orb.png",
-  phoenix_revival_skill: "assets/skill_phoenix_revival.png",
-  baseball_bat: "assets/baseball_bat.png",
-  medkit: "assets/medkit.png",
-  wood: "assets/wood.png",
-  bow: "assets/wooden_bow.png",
-  arrow: "assets/wooden_arrow.png",
-  scrap_metal: "assets/scrap_metal.png",
-  duct_tape: "assets/duct_tape.png",
-  nails: "assets/nails.png",
-  plastic_fragments: "assets/plastic_fragments.png",
-  wood_planks: "assets/wood_planks.png",
-  steel_plates: "assets/steel_plates.png",
-  hammer: "assets/hammer.png",
-  crowbar: "assets/crowbar.png",
-  axe: "assets/axe.png",
-  reinforced_axe: "assets/reinforced_axe.png",
-  wood_barricade: "assets/wood_barricade.png",
-};
+// ITEM_ICONS is imported from items.js and maps item ids to icon paths.
 
 // Preload image objects for item icons so they can be drawn on the canvas
 const ITEM_IMAGES = {};
@@ -802,8 +778,17 @@ function update() {
         Math.hypot(c.x - player.x, c.y - player.y) <= LOOT_DIST &&
         (!c.opened || c.item),
     );
-    if (cont) {
-      looting = cont;
+    const shelf = walls.find(
+      (w) =>
+        Math.hypot(
+          w.x + SEGMENT_SIZE / 2 - player.x,
+          w.y + SEGMENT_SIZE / 2 - player.y,
+        ) <= LOOT_DIST &&
+        (!w.opened || w.item),
+    );
+    const target = cont || shelf;
+    if (target) {
+      looting = target;
       lootTimer = LOOT_TIME;
       lootFill.style.width = "0%";
       lootDiv.style.display = "block";
@@ -811,7 +796,9 @@ function update() {
   }
 
   if (looting) {
-    const dist = Math.hypot(looting.x - player.x, looting.y - player.y);
+    const lx = "size" in looting ? looting.x + SEGMENT_SIZE / 2 : looting.x;
+    const ly = "size" in looting ? looting.y + SEGMENT_SIZE / 2 : looting.y;
+    const dist = Math.hypot(lx - player.x, ly - player.y);
     if (dist > LOOT_DIST || !keys["f"]) {
       looting = null;
       lootDiv.style.display = "none";
@@ -820,16 +807,25 @@ function update() {
       lootFill.style.width = `${((LOOT_TIME - lootTimer) / LOOT_TIME) * 100}%`;
       if (lootTimer <= 0) {
         if (!looting.opened) {
-          openContainer(looting);
+          if ("size" in looting) {
+            openShelf(looting, ITEM_IDS);
+          } else {
+            openContainer(looting);
+          }
         }
-        if (addItem(inventory, looting.item, 1)) {
-          pickupMsg.textContent = `Picked up ${looting.item}`;
-          looting.item = null;
-          pickupMessageTimer = 60;
-          renderInventory();
-          renderHotbar();
+        if (looting.item) {
+          if (addItem(inventory, looting.item, 1)) {
+            pickupMsg.textContent = `Picked up ${looting.item}`;
+            looting.item = null;
+            pickupMessageTimer = 60;
+            renderInventory();
+            renderHotbar();
+          } else {
+            pickupMsg.textContent = "Inventory Full";
+            pickupMessageTimer = 60;
+          }
         } else {
-          pickupMsg.textContent = "Inventory Full";
+          pickupMsg.textContent = "Nothing found";
           pickupMessageTimer = 60;
         }
         looting = null;
@@ -1020,7 +1016,9 @@ function render() {
   walls.forEach((w) => {
     const img = WALL_IMAGES[w.material];
     if (img && img.complete) {
+      ctx.globalAlpha = w.opened ? 0.5 : 1;
       ctx.drawImage(img, w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
+      ctx.globalAlpha = 1;
     } else {
       ctx.fillStyle = "gray";
       ctx.fillRect(w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);

--- a/frontend/src/walls.js
+++ b/frontend/src/walls.js
@@ -26,6 +26,8 @@ export function createWall(gx, gy, material = "wood") {
     hp,
     maxHp: hp,
     damageTimer: 0,
+    opened: false,
+    item: null,
   };
 }
 
@@ -148,4 +150,17 @@ export function updateWalls(walls) {
     if (w.damageTimer > 0) w.damageTimer--;
     if (w.hp <= 0) walls.splice(i, 1);
   }
+}
+
+export const SHELF_LOOT_CHANCE = 0.2;
+
+export function openShelf(wall, itemPool = []) {
+  if (!wall.opened) {
+    wall.opened = true;
+    if (Math.random() < SHELF_LOOT_CHANCE && itemPool.length > 0) {
+      const idx = Math.floor(Math.random() * itemPool.length);
+      wall.item = itemPool[idx];
+    }
+  }
+  return wall.item;
 }

--- a/frontend/tests/shelf.test.js
+++ b/frontend/tests/shelf.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWall, openShelf } from "../src/walls.js";
+
+function withRandomValues(values, fn) {
+  const orig = Math.random;
+  let i = 0;
+  Math.random = () => values[i++] ?? 1;
+  try {
+    fn();
+  } finally {
+    Math.random = orig;
+  }
+}
+
+test("openShelf returns item when chance succeeds", () => {
+  const w = createWall(0, 0, "wood");
+  withRandomValues([0, 0], () => {
+    const item = openShelf(w, ["a", "b"]);
+    assert.strictEqual(w.opened, true);
+    assert.strictEqual(item, "a");
+    assert.strictEqual(w.item, "a");
+  });
+});
+
+test("openShelf may give no item", () => {
+  const w = createWall(0, 0, "wood");
+  withRandomValues([0.99], () => {
+    const item = openShelf(w, ["a"]);
+    assert.strictEqual(w.opened, true);
+    assert.strictEqual(item, null);
+    assert.strictEqual(w.item, null);
+  });
+});


### PR DESCRIPTION
## Summary
- move item icon data to `items.js`
- add shelf loot state and searching logic
- let shelves fade after being looted
- support looting shelves in main loop
- document shelf looting
- test shelf looting

## Testing
- `npx prettier -w frontend/src/items.js frontend/src/walls.js frontend/src/main.js frontend/tests/shelf.test.js docs/zombie_game.md`
- `npm test --prefix frontend`
- `pip install -q fastapi`
- `pip install -q httpx`
- `pytest -q backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_686dea926800832394bdc1d415c3cab2