### PR TITLE
Fix shelf loot giving spells

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -55,7 +55,7 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 
 Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box now contains **Scrap Metal**, **Duct Tape**, **Nails**, or a **Medkit** with equal probability. If there is room in your hotbar or inventory the item is added automatically. Otherwise a brief "Inventory Full" message appears. Opened boxes appear faded so you know they have been searched.
 
-Shelves can now be searched the same way. Stand beside a shelf segment, face it, and hold **F** to rummage through. Searching takes time and each shelf can only be looted once. Looted shelves fade just like opened boxes. Shelves usually contain nothing, but occasionally you might find any random item tucked away.
+Shelves can now be searched the same way. Stand beside a shelf segment, face it, and hold **F** to rummage through. Searching takes time and each shelf can only be looted once. Looted shelves fade just like opened boxes. Shelves usually contain nothing, but very rarely yield extra crafting materials like **Scrap Metal**, **Duct Tape**, **Nails**, **Plastic Fragments**, **Wood Planks**, or **Steel Plates**.
 
 Equip a Medkit and press the **Space** key or left mouse button to restore up to 3 health without exceeding your maximum.
 

--- a/frontend/src/items.js
+++ b/frontend/src/items.js
@@ -32,6 +32,16 @@ export const ITEM_ICONS = {
 
 export const ITEM_IDS = Object.keys(ITEM_ICONS);
 
+// Items considered basic crafting materials for shelves and recipes
+export const CRAFTING_MATERIALS = [
+  "scrap_metal",
+  "duct_tape",
+  "nails",
+  "plastic_fragments",
+  "wood_planks",
+  "steel_plates",
+];
+
 import { PLAYER_MAX_HEALTH } from "./game_logic.js";
 
 export function applyConsumableEffect(player, itemId) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -61,6 +61,7 @@ import {
   CONSUMABLE_ITEMS,
   ITEM_ICONS,
   ITEM_IDS,
+  CRAFTING_MATERIALS,
 } from "./items.js";
 import { getItemCooldown } from "./cooldowns.js";
 const canvas = document.getElementById("gameCanvas");
@@ -846,7 +847,8 @@ function update() {
       if (lootTimer <= 0) {
         if (!looting.opened) {
           if ("size" in looting) {
-            openShelf(looting, ITEM_IDS);
+            // Shelves only contain basic crafting materials
+            openShelf(looting, CRAFTING_MATERIALS);
           } else {
             openContainer(looting);
           }
@@ -987,7 +989,7 @@ function update() {
       renderHotbar();
     }
   }
-  
+
   zombies.forEach((z) => {
     moveZombie(z, player, walls, 1, canvas.width, canvas.height, zombies);
     if (z.attackCooldown > 0) z.attackCooldown--;

--- a/frontend/tests/shelf.test.js
+++ b/frontend/tests/shelf.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createWall, openShelf } from "../src/walls.js";
+import { CRAFTING_MATERIALS } from "../src/items.js";
 
 function withRandomValues(values, fn) {
   const orig = Math.random;
@@ -30,5 +31,20 @@ test("openShelf may give no item", () => {
     assert.strictEqual(w.opened, true);
     assert.strictEqual(item, null);
     assert.strictEqual(w.item, null);
+  });
+});
+
+test("CRAFTING_MATERIALS excludes spells", () => {
+  const hasSpell = CRAFTING_MATERIALS.some(
+    (id) => id.includes("spell") || id.includes("skill"),
+  );
+  assert.strictEqual(hasSpell, false);
+});
+
+test("openShelf returns crafting material from pool", () => {
+  const w = createWall(0, 0, "wood");
+  withRandomValues([0, 0], () => {
+    const item = openShelf(w, CRAFTING_MATERIALS);
+    assert.ok(CRAFTING_MATERIALS.includes(item));
   });
 });


### PR DESCRIPTION
## Summary
- restrict shelf loot table to crafting materials
- update docs for new shelf loot rules
- test shelf loot only gives crafting items

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dfe5354988323a08921ab8033ac23