### PR TITLE
Ensure door spawns with clear exit

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -14,6 +14,8 @@ npm run dev
 
 The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. Five basic zombies enter through this door at the beginning of **Wave&nbsp;1**, shown in a counter at the top right which now uses black text for visibility. Once all five are defeated a Victory screen appears with a button to play again.
 Zombies now treat each other as obstacles, so only one can occupy a grid space at a time and new zombies won't spawn on top of existing ones.
+The spawn door is guaranteed to have an open space just inside the arena so
+fresh zombies are never trapped when they appear.
 
 Shelving now forms organized aisles built from steel, wood, and plastic segments. These shelves are breakable, with steel being the hardest to destroy and plastic the weakest. Damaged shelves flash and briefly show a health bar before collapsing. The layout generator spaces aisles widely so there is plenty of room to maneuver while still providing clear paths and chokepoints.
 Use crafted tools like the **Hammer**, **Crowbar**, or **Axe** to chip away at shelves. Melee swings now deal more damage so only a handful are needed to break a shelf. Once its health reaches zero the shelf disappears, dropping building materials.

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -108,18 +108,26 @@ export function spawnContainers(width, height, walls = [], count = 3) {
 
 export function createSpawnDoor(width, height, walls = []) {
   let door;
+  let inside;
   do {
     const edge = Math.floor(Math.random() * 4);
     if (edge === 0) {
       door = { x: Math.random() * width, y: 0 };
+      inside = { x: door.x, y: SEGMENT_SIZE };
     } else if (edge === 1) {
       door = { x: Math.random() * width, y: height };
+      inside = { x: door.x, y: height - SEGMENT_SIZE };
     } else if (edge === 2) {
       door = { x: 0, y: Math.random() * height };
+      inside = { x: SEGMENT_SIZE, y: door.y };
     } else {
       door = { x: width, y: Math.random() * height };
+      inside = { x: width - SEGMENT_SIZE, y: door.y };
     }
-  } while (walls.some((w) => circleRectColliding(door, w, 10)));
+  } while (
+    walls.some((w) => circleRectColliding(door, w, 10)) ||
+    walls.some((w) => circleRectColliding(inside, w, 10))
+  );
   return door;
 }
 

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -16,6 +16,7 @@ import {
   attackZombiesWithKills,
   ZOMBIE_MAX_HEALTH,
   spawnZombieAtDoor,
+  createSpawnDoor,
   spawnZombieWave,
   createContainer,
   spawnContainers,
@@ -139,6 +140,26 @@ test("spawnZombieAtDoor uses random chance for fire variant", () => {
   Math.random = originalRandom;
   assert.strictEqual(fire.variant, "fire");
   assert.strictEqual(normal.variant, "normal");
+});
+
+test("createSpawnDoor leaves an open interior space", () => {
+  const walls = [
+    { x: 0, y: 0, size: SEGMENT_SIZE },
+    { x: 0, y: SEGMENT_SIZE, size: SEGMENT_SIZE },
+  ];
+  for (let i = 0; i < 10; i++) {
+    const door = createSpawnDoor(120, 80, walls);
+    let inside;
+    if (door.x === 0) inside = { x: SEGMENT_SIZE, y: door.y };
+    else if (door.x === 120) inside = { x: 120 - SEGMENT_SIZE, y: door.y };
+    else if (door.y === 0) inside = { x: door.x, y: SEGMENT_SIZE };
+    else if (door.y === 80) inside = { x: door.x, y: 80 - SEGMENT_SIZE };
+    else continue;
+    assert.strictEqual(
+      walls.some((w) => circleRectColliding(inside, w, 10)),
+      false,
+    );
+  }
 });
 
 test("spawnZombieWave creates multiple normal zombies near door", () => {


### PR DESCRIPTION
## Summary
- guarantee that the spawn door isn't blocked by walls
- document that zombies always have a clear path out of the door
- test door placement for an open interior tile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e054b67c88323ac87e2603f1a3668