### PR TITLE
Move player, arrow, and orb scripts into entities folder

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 This project is split into separate frontend and backend components.
 
-- **Frontend**: HTML5/JavaScript client rendered on a `<canvas>` element using a lightweight setup with Vite. Game logic is kept independent from rendering to encourage modularity. Source files under `frontend/src/` are organized into `components/`, `entities/`, `scenes/`, `systems/` and `utils/` directories.
+- **Frontend**: HTML5/JavaScript client rendered on a `<canvas>` element using a lightweight setup with Vite. Game logic is kept independent from rendering to encourage modularity. Source files under `frontend/src/` are organized into `components/`, `entities/`, `scenes/`, `systems/` and `utils/` directories. Common game objects like the player, arrows and floating orbs live in the `entities` folder.
 - **Backend**: Python FastAPI service providing API endpoints. Initially exposes a simple health check and is prepared for future features like multiplayer or persistence.
 
 Both sides communicate via HTTP or WebSockets. The repository emphasizes clear separation of concerns and maintainable code.

--- a/frontend/src/entities/arrow.js
+++ b/frontend/src/entities/arrow.js
@@ -2,8 +2,8 @@ export const ARROW_SPEED = 3;
 export const ARROW_DAMAGE = 2;
 export const ARROW_PREVIEW_RANGE = 12 * 40;
 
-import { circleRectColliding, isColliding } from "./game_logic.js";
-import { damageWall } from "./walls.js";
+import { circleRectColliding, isColliding } from "../game_logic.js";
+import { damageWall } from "../walls.js";
 
 export function predictArrowEndpoint(x, y, direction, walls, zombies = []) {
   const len = Math.hypot(direction.x, direction.y);

--- a/frontend/src/entities/orbs.js
+++ b/frontend/src/entities/orbs.js
@@ -12,7 +12,7 @@ export function createOrbs(count) {
   }));
 }
 
-import { isColliding } from "./game_logic.js";
+import { isColliding } from "../game_logic.js";
 export function updateOrbs(
   orbs,
   player,

--- a/frontend/src/entities/player.js
+++ b/frontend/src/entities/player.js
@@ -1,4 +1,4 @@
-import { attackZombies } from "./game_logic.js";
+import { attackZombies } from "../game_logic.js";
 
 export const PHOENIX_KNOCKBACK_RADIUS = 40;
 // Increased so the revival blast sends zombies much farther away

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -27,7 +27,7 @@ import {
   createPlayer,
   resetPlayerForNewGame,
   tryPhoenixRevival,
-} from "./player.js";
+} from "./entities/player.js";
 import {
   createInventory,
   addItem,
@@ -51,9 +51,13 @@ import {
   fireballStats,
   updateExplosions,
 } from "./spells.js";
-import { createArrow, updateArrows, predictArrowEndpoint } from "./arrow.js";
+import {
+  createArrow,
+  updateArrows,
+  predictArrowEndpoint,
+} from "./entities/arrow.js";
 import { SKILL_INFO, SKILL_UPGRADERS } from "./skill_tree.js";
-import { createOrbs, updateOrbs } from "./orbs.js";
+import { createOrbs, updateOrbs } from "./entities/orbs.js";
 import { makeDraggable } from "./ui.js";
 
 import {

--- a/frontend/tests/arrow.test.js
+++ b/frontend/tests/arrow.test.js
@@ -4,7 +4,7 @@ import {
   createArrow,
   updateArrows,
   predictArrowEndpoint,
-} from "../src/arrow.js";
+} from "../src/entities/arrow.js";
 
 // helper stubs
 import { circleRectColliding, isColliding } from "../src/game_logic.js";

--- a/frontend/tests/items.test.js
+++ b/frontend/tests/items.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createPlayer } from "../src/player.js";
+import { createPlayer } from "../src/entities/player.js";
 import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
 import { applyConsumableEffect } from "../src/items.js";
 

--- a/frontend/tests/orbs.test.js
+++ b/frontend/tests/orbs.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createOrbs, updateOrbs } from "../src/orbs.js";
+import { createOrbs, updateOrbs } from "../src/entities/orbs.js";
 
 // stub for collision
 import { isColliding } from "../src/game_logic.js";

--- a/frontend/tests/phoenix.test.js
+++ b/frontend/tests/phoenix.test.js
@@ -4,7 +4,7 @@ import {
   createPlayer,
   tryPhoenixRevival,
   PHOENIX_KNOCKBACK_FORCE,
-} from "../src/player.js";
+} from "../src/entities/player.js";
 import { PLAYER_MAX_HEALTH, createZombie } from "../src/game_logic.js";
 
 test("tryPhoenixRevival revives player", () => {

--- a/frontend/tests/player.test.js
+++ b/frontend/tests/player.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createPlayer, resetPlayerForNewGame } from "../src/player.js";
+import { createPlayer, resetPlayerForNewGame } from "../src/entities/player.js";
 import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
 
 test("resetPlayerForNewGame clears abilities and restores health", () => {

--- a/frontend/tests/skill_tree.test.js
+++ b/frontend/tests/skill_tree.test.js
@@ -6,7 +6,7 @@ import {
   upgradePhoenixRevival,
   SKILL_INFO,
 } from "../src/skill_tree.js";
-import { createPlayer, resetPlayerForNewGame } from "../src/player.js";
+import { createPlayer, resetPlayerForNewGame } from "../src/entities/player.js";
 import { createInventory } from "../src/inventory.js";
 import { PLAYER_MAX_HEALTH } from "../src/game_logic.js";
 import { addItem, moveToHotbar } from "../src/inventory.js";


### PR DESCRIPTION
## Summary
- place player.js, arrow.js and orbs.js under `src/entities`
- update imports in `main.js`
- fix test imports for new paths
- document the location of common entities

## Testing
- `npm test --prefix frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f6555a0b48323b352904293e4d10a