### PR TITLE
Refactor UI into components

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,7 @@ This project is split into separate frontend and backend components.
 - **Frontend**: HTML5/JavaScript client rendered on a `<canvas>` element using a lightweight setup with Vite. Game logic is kept independent from rendering to encourage modularity. Source files under `frontend/src/` are organized into `components/`, `entities/`, `scenes/`, `systems/` and `utils/` directories. Common game objects like the player, arrows and floating orbs live in the `entities` folder.
   Zombie behavior resides in `frontend/src/entities/zombie.js` to keep AI code modular.
   Reusable math helpers like `moveTowards` and `isColliding` live in `frontend/src/utils/geometry.js`.
+  UI elements such as the inventory, skill tree and HUD are implemented in separate modules under `frontend/src/components/`.
 - **Backend**: Python FastAPI service providing API endpoints. Initially exposes a simple health check and is prepared for future features like multiplayer or persistence.
 
 Both sides communicate via HTTP or WebSockets. The repository emphasizes clear separation of concerns and maintainable code.

--- a/frontend/src/components/hud.js
+++ b/frontend/src/components/hud.js
@@ -1,0 +1,51 @@
+export function createHUD({ pickupMsg, waveCounterDiv }) {
+  let pickupTimer = 0;
+
+  function showPickupMessage(text) {
+    pickupMsg.textContent = text;
+    pickupTimer = 60;
+  }
+
+  function clearPickupMessage() {
+    pickupMsg.textContent = "";
+    pickupTimer = 0;
+  }
+  function update() {
+    if (pickupTimer > 0) {
+      pickupTimer--;
+      if (pickupTimer === 0) pickupMsg.textContent = "";
+    }
+  }
+
+  function setWave(wave) {
+    waveCounterDiv.textContent = `Wave ${wave}`;
+  }
+
+  function showWaveCounter() {
+    waveCounterDiv.style.display = "block";
+  }
+
+  function hideWaveCounter() {
+    waveCounterDiv.style.display = "none";
+  }
+
+  function render(ctx, player, inventory, countItem) {
+    ctx.fillStyle = "black";
+    ctx.font = "16px sans-serif";
+    ctx.textAlign = "left";
+    ctx.fillText(`Health: ${player.health}`, 10, 20);
+    if (player.weapon && player.weapon.type === "bow") {
+      ctx.fillText(`Arrows: ${countItem(inventory, "arrow")}`, 10, 40);
+    }
+  }
+
+  return {
+    showPickupMessage,
+    update,
+    clearPickupMessage,
+    setWave,
+    showWaveCounter,
+    hideWaveCounter,
+    render,
+  };
+}

--- a/frontend/src/components/inventory-ui.js
+++ b/frontend/src/components/inventory-ui.js
@@ -1,0 +1,284 @@
+import {
+  moveItem,
+  moveToHotbar,
+  moveFromHotbar,
+  swapHotbar,
+  swapInventoryHotbar,
+} from "../inventory.js";
+export function createInventoryUI({
+  inventoryDiv,
+  inventoryGrid,
+  hotbarDiv,
+  inventoryBar,
+  inventoryClose,
+  inventoryPos,
+}) {
+  let open = false;
+  let selectedSlot = null;
+
+  function renderInventory(
+    inventory,
+    player,
+    fireballCooldown,
+    itemIcons,
+    getItemCooldown,
+  ) {
+    inventoryGrid.innerHTML = "";
+    inventory.slots.forEach((slot, i) => {
+      const div = document.createElement("div");
+      div.dataset.index = i;
+      Object.assign(div.style, {
+        width: "40px",
+        height: "40px",
+        border: "1px solid white",
+        color: "white",
+        background: "rgba(0,0,0,0.7)",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        position: "relative",
+      });
+      if (
+        selectedSlot &&
+        selectedSlot.type === "inventory" &&
+        selectedSlot.index === i
+      ) {
+        div.style.outline = "2px solid yellow";
+      }
+      if (slot.item) {
+        if (itemIcons[slot.item]) {
+          const img = document.createElement("img");
+          img.src = itemIcons[slot.item];
+          img.style.width = "32px";
+          img.style.height = "32px";
+          div.appendChild(img);
+        } else {
+          div.textContent = "?";
+        }
+        if (slot.count > 1) {
+          const count = document.createElement("span");
+          count.textContent = slot.count;
+          Object.assign(count.style, {
+            position: "absolute",
+            bottom: "0",
+            right: "2px",
+            fontSize: "10px",
+          });
+          div.appendChild(count);
+        }
+        const { remaining, max } = getItemCooldown(
+          slot.item,
+          player,
+          fireballCooldown,
+        );
+        if (max > 0 && remaining > 0) {
+          const deg = (remaining / max) * 360;
+          const overlay = document.createElement("div");
+          Object.assign(overlay.style, {
+            position: "absolute",
+            inset: "0",
+            borderRadius: "2px",
+            pointerEvents: "none",
+            background: `conic-gradient(from -90deg, rgba(128,128,128,0.6) 0deg ${deg}deg, transparent ${deg}deg 360deg)`,
+          });
+          div.appendChild(overlay);
+        }
+      }
+      div.addEventListener("mousedown", () => {
+        if (!selectedSlot) {
+          selectedSlot = { type: "inventory", index: i };
+        } else {
+          if (selectedSlot.type === "inventory") {
+            moveItem(inventory, selectedSlot.index, i);
+          } else {
+            swapInventoryHotbar(i, selectedSlot.index);
+          }
+          selectedSlot = null;
+        }
+        renderInventory(
+          inventory,
+          player,
+          fireballCooldown,
+          itemIcons,
+          getItemCooldown,
+        );
+        renderHotbar(
+          inventory,
+          player,
+          fireballCooldown,
+          itemIcons,
+          getItemCooldown,
+        );
+      });
+      div.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+        const slot = inventory.slots[i];
+        if (!slot.item) return;
+        const idx = inventory.hotbar.findIndex((s) => !s.item);
+        if (idx !== -1) {
+          moveToHotbar(i, idx);
+          selectedSlot = null;
+          renderInventory(
+            inventory,
+            player,
+            fireballCooldown,
+            itemIcons,
+            getItemCooldown,
+          );
+          renderHotbar(
+            inventory,
+            player,
+            fireballCooldown,
+            itemIcons,
+            getItemCooldown,
+          );
+        }
+      });
+      inventoryGrid.appendChild(div);
+    });
+  }
+
+  function renderHotbar(
+    inventory,
+    player,
+    fireballCooldown,
+    itemIcons,
+    getItemCooldown,
+  ) {
+    hotbarDiv.innerHTML = "";
+    inventory.hotbar.forEach((slot, i) => {
+      const div = document.createElement("div");
+      Object.assign(div.style, {
+        width: "40px",
+        height: "40px",
+        border: "1px solid white",
+        color: "white",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        position: "relative",
+      });
+      if (
+        selectedSlot &&
+        selectedSlot.type === "hotbar" &&
+        selectedSlot.index === i
+      ) {
+        div.style.outline = "2px solid yellow";
+      }
+      if (slot.item) {
+        if (itemIcons[slot.item]) {
+          const img = document.createElement("img");
+          img.src = itemIcons[slot.item];
+          img.style.width = "32px";
+          img.style.height = "32px";
+          div.appendChild(img);
+        } else {
+          div.textContent = "?";
+        }
+        if (slot.count > 1) {
+          const count = document.createElement("span");
+          count.textContent = slot.count;
+          Object.assign(count.style, {
+            position: "absolute",
+            bottom: "0",
+            right: "2px",
+            fontSize: "10px",
+          });
+          div.appendChild(count);
+        }
+        const { remaining, max } = getItemCooldown(
+          slot.item,
+          player,
+          fireballCooldown,
+        );
+        if (max > 0 && remaining > 0) {
+          const deg = (remaining / max) * 360;
+          const overlay = document.createElement("div");
+          Object.assign(overlay.style, {
+            position: "absolute",
+            inset: "0",
+            borderRadius: "2px",
+            pointerEvents: "none",
+            background: `conic-gradient(from -90deg, rgba(128,128,128,0.6) 0deg ${deg}deg, transparent ${deg}deg 360deg)`,
+          });
+          div.appendChild(overlay);
+        }
+      }
+      if (i === inventory.active) {
+        div.style.borderColor = "yellow";
+      }
+      div.addEventListener("mousedown", () => {
+        if (!selectedSlot) {
+          selectedSlot = { type: "hotbar", index: i };
+        } else {
+          if (selectedSlot.type === "hotbar") {
+            swapHotbar(selectedSlot.index, i);
+          } else {
+            swapInventoryHotbar(selectedSlot.index, i);
+          }
+          selectedSlot = null;
+        }
+        renderInventory(
+          inventory,
+          player,
+          fireballCooldown,
+          itemIcons,
+          getItemCooldown,
+        );
+        renderHotbar(
+          inventory,
+          player,
+          fireballCooldown,
+          itemIcons,
+          getItemCooldown,
+        );
+      });
+      div.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+        const idx = inventory.slots.findIndex((s) => !s.item);
+        if (idx !== -1) {
+          moveFromHotbar(i, idx);
+          selectedSlot = null;
+          renderInventory(
+            inventory,
+            player,
+            fireballCooldown,
+            itemIcons,
+            getItemCooldown,
+          );
+          renderHotbar(
+            inventory,
+            player,
+            fireballCooldown,
+            itemIcons,
+            getItemCooldown,
+          );
+        }
+      });
+      hotbarDiv.appendChild(div);
+    });
+  }
+
+  function toggleInventory(flag) {
+    if (flag === open) return;
+    open = flag;
+    if (open) {
+      if (inventoryPos.left !== null) {
+        inventoryDiv.style.left = inventoryPos.left + "px";
+        inventoryDiv.style.top = inventoryPos.top + "px";
+        inventoryDiv.style.transform = "none";
+      } else {
+        inventoryDiv.style.left = "50%";
+        inventoryDiv.style.top = "50%";
+        inventoryDiv.style.transform = "translate(-50%, -50%)";
+      }
+      inventoryDiv.style.display = "block";
+    } else {
+      inventoryPos.left = inventoryDiv.offsetLeft;
+      inventoryPos.top = inventoryDiv.offsetTop;
+      inventoryDiv.style.display = "none";
+    }
+  }
+
+  return { renderInventory, renderHotbar, toggleInventory, isOpen: () => open };
+}

--- a/frontend/src/components/skill-tree-ui.js
+++ b/frontend/src/components/skill-tree-ui.js
@@ -1,0 +1,127 @@
+export function createSkillTreeUI(
+  {
+    skillTreeDiv,
+    skillTreeBar,
+    skillTreeClose,
+    skillPointsDiv,
+    skillGrid,
+    skillDetails,
+    skillNameDiv,
+    skillDescDiv,
+    skillLevelsDiv,
+    skillLevelDiv,
+    skillCostDiv,
+    skillUpgradeBtn,
+    skillTreePos,
+  },
+  itemIcons,
+) {
+  let open = false;
+  let selectedSkill = null;
+
+  function renderSkillTree(player, skillInfo) {
+    skillPointsDiv.textContent = `Fire Mutation Points Available: ${player.fireMutationPoints}`;
+    skillGrid.innerHTML = "";
+    const skills = skillInfo.map((info) => ({
+      ...info,
+      level: player.abilities[info.levelKey] || 0,
+    }));
+    skills.forEach((s) => {
+      const tile = document.createElement("div");
+      const nextCost = s.level < s.max ? s.costs[s.level + 1] : null;
+      tile.className = "skill-node";
+      if (s.level >= s.max) tile.classList.add("maxed");
+      else if (s.level > 0) tile.classList.add("unlocked");
+      else tile.classList.add("locked");
+      if (nextCost && player.fireMutationPoints >= nextCost) {
+        tile.classList.add("available");
+      }
+      if (selectedSkill && selectedSkill.id === s.id) {
+        tile.style.outline = "2px solid yellow";
+      }
+      const img = document.createElement("img");
+      img.src = itemIcons[s.id];
+      img.style.width = "48px";
+      img.style.height = "48px";
+      img.style.opacity = s.level > 0 ? 1 : 0.5;
+      tile.appendChild(img);
+      const label = document.createElement("div");
+      label.style.fontSize = "12px";
+      label.textContent = `Lv ${s.level}/${s.max}`;
+      tile.appendChild(label);
+      tile.addEventListener("mousedown", () => {
+        selectedSkill = s;
+        updateSkillDetails(player);
+        renderSkillTree(player, skillInfo);
+      });
+      skillGrid.appendChild(tile);
+    });
+  }
+
+  function updateSkillDetails(player) {
+    if (!selectedSkill) {
+      skillDetails.style.display = "none";
+      return;
+    }
+    const level = selectedSkill.level;
+    const nextCost =
+      level < selectedSkill.max ? selectedSkill.costs[level + 1] : null;
+    skillNameDiv.textContent = selectedSkill.name;
+    skillDescDiv.textContent = selectedSkill.description;
+    skillLevelsDiv.innerHTML = "";
+    if (selectedSkill.levels) {
+      selectedSkill.levels.forEach((lv, idx) => {
+        const li = document.createElement("li");
+        li.textContent = `Lv ${idx + 1}: ${lv.effect} (Cost: ${lv.cost})`;
+        skillLevelsDiv.appendChild(li);
+      });
+    }
+    skillLevelDiv.textContent = `Level ${level}/${selectedSkill.max}`;
+    skillCostDiv.textContent = nextCost ? `Cost: ${nextCost}` : "Max level";
+    skillUpgradeBtn.textContent = level === 0 ? "Unlock" : "Upgrade";
+    skillDetails.style.display = "block";
+  }
+
+  function toggleSkillTree(flag, player, skillInfo) {
+    if (flag === open) return;
+    open = flag;
+    if (open) {
+      if (skillTreePos.left !== null) {
+        skillTreeDiv.style.left = skillTreePos.left + "px";
+        skillTreeDiv.style.top = skillTreePos.top + "px";
+        skillTreeDiv.style.transform = "none";
+      } else {
+        skillTreeDiv.style.left = "50%";
+        skillTreeDiv.style.top = "50%";
+        skillTreeDiv.style.transform = "translate(-50%, -50%)";
+      }
+      skillTreeDiv.style.display = "block";
+      renderSkillTree(player, skillInfo);
+    } else {
+      skillTreePos.left = skillTreeDiv.offsetLeft;
+      skillTreePos.top = skillTreeDiv.offsetTop;
+      skillTreeDiv.style.display = "none";
+      selectedSkill = null;
+      updateSkillDetails(player);
+    }
+  }
+
+  skillUpgradeBtn.addEventListener("click", () => {
+    if (!selectedSkill) return;
+    if (onUpgrade) onUpgrade(selectedSkill);
+  });
+
+  let onUpgrade = null;
+  function setUpgradeHandler(fn) {
+    onUpgrade = fn;
+  }
+
+  return {
+    renderSkillTree,
+    updateSkillDetails,
+    toggleSkillTree,
+    setUpgradeHandler,
+    getSelectedSkill: () => selectedSkill,
+    isOpen: () => open,
+  };
+}


### PR DESCRIPTION
## Summary
- move inventory/hotbar rendering to `components/inventory-ui.js`
- add `components/skill-tree-ui.js` for skill tree interface
- add `components/hud.js` for heads-up display
- refactor `main.js` to use the new UI components
- document UI modules in architecture docs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68701ce113988323a29e7edc67b5654c