### PR TITLE
Refactor game loop into systems

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,7 @@ This project is split into separate frontend and backend components.
   Zombie behavior resides in `frontend/src/entities/zombie.js` to keep AI code modular.
   Reusable math helpers like `moveTowards` and `isColliding` live in `frontend/src/utils/geometry.js`.
   UI elements such as the inventory, skill tree and HUD are implemented in separate modules under `frontend/src/components/`.
+  Game systems such as rendering, abilities and collisions reside in `frontend/src/systems/` to keep the main loop minimal. The collision system manages all projectile interactions as well as player contacts with zombies and world items.
 - **Backend**: Python FastAPI service providing API endpoints. Initially exposes a simple health check and is prepared for future features like multiplayer or persistence.
 
 Both sides communicate via HTTP or WebSockets. The repository emphasizes clear separation of concerns and maintainable code.

--- a/frontend/src/entities/arrow.js
+++ b/frontend/src/entities/arrow.js
@@ -2,7 +2,7 @@ export const ARROW_SPEED = 3;
 export const ARROW_DAMAGE = 2;
 export const ARROW_PREVIEW_RANGE = 12 * 40;
 
-import { circleRectColliding } from "../game_logic.js";
+import { circleRectColliding } from "../systems/collision-system.js";
 import { isColliding } from "../utils/geometry.js";
 import { damageWall } from "../walls.js";
 

--- a/frontend/src/entities/zombie.js
+++ b/frontend/src/entities/zombie.js
@@ -1,4 +1,5 @@
-import { circleRectColliding, SEGMENT_SIZE } from "../game_logic.js";
+import { SEGMENT_SIZE } from "../game_logic.js";
+import { circleRectColliding } from "../systems/collision-system.js";
 import { moveTowards, isColliding } from "../utils/geometry.js";
 
 export const ZOMBIE_MAX_HEALTH = 2;
@@ -366,15 +367,6 @@ export function updateZombies(zombies, player, walls, width, height) {
   for (const z of zombies) {
     moveZombie(z, player, walls, 1, width, height, zombies);
     if (z.attackCooldown > 0) z.attackCooldown--;
-    if (
-      isColliding(z, player, 10) &&
-      player.damageCooldown <= 0 &&
-      z.attackCooldown <= 0
-    ) {
-      player.health--;
-      player.damageCooldown = 30;
-      z.attackCooldown = 30;
-    }
   }
 }
 

--- a/frontend/src/game_logic.js
+++ b/frontend/src/game_logic.js
@@ -1,4 +1,5 @@
 import { moveTowards, isColliding } from "./utils/geometry.js";
+import { circleRectColliding } from "./systems/collision-system.js";
 
 export function spawnPlayer(width, height, walls = []) {
   let player;
@@ -75,11 +76,3 @@ export function createSpawnDoor(width, height, walls = []) {
 export const PLAYER_MAX_HEALTH = 10;
 
 export const SEGMENT_SIZE = 40;
-
-export function circleRectColliding(circle, rect, radius) {
-  const closestX = Math.max(rect.x, Math.min(circle.x, rect.x + rect.size));
-  const closestY = Math.max(rect.y, Math.min(circle.y, rect.y + rect.size));
-  const dx = circle.x - closestX;
-  const dy = circle.y - closestY;
-  return dx * dx + dy * dy < radius * radius;
-}

--- a/frontend/src/spells.js
+++ b/frontend/src/spells.js
@@ -19,7 +19,7 @@ export function fireballStats(level) {
   return { damage, radius, pierce };
 }
 
-import { circleRectColliding } from "./game_logic.js";
+import { circleRectColliding } from "./systems/collision-system.js";
 import { isColliding } from "./utils/geometry.js";
 import { damageWall } from "./walls.js";
 export function createFireball(x, y, direction, level = 1, damageMult = 1) {

--- a/frontend/src/systems/ability-system.js
+++ b/frontend/src/systems/ability-system.js
@@ -1,0 +1,78 @@
+import { createFireball } from "../spells.js";
+import { createArrow } from "../entities/arrow.js";
+import { updateOrbs } from "../entities/orbs.js";
+import { getActiveHotbarItem, countItem, removeItem } from "../inventory.js";
+import { dropLoot } from "../loot.js";
+
+export function updateAbilities({
+  player,
+  inventory,
+  fireballs,
+  fireOrbs,
+  arrows,
+  zombies,
+  mousePos,
+  worldItems,
+  hud,
+  renderInventory,
+  renderHotbar,
+  useHeld,
+  aimHeld,
+  aimRelease,
+  fireballCooldown,
+}) {
+  if (fireballCooldown.value > 0) fireballCooldown.value--;
+
+  const activeSlot = getActiveHotbarItem(inventory);
+  if (
+    activeSlot &&
+    activeSlot.item === "fireball_spell" &&
+    player.abilities.fireball &&
+    useHeld &&
+    fireballCooldown.value <= 0
+  ) {
+    if (countItem(inventory, "fire_core") > 0) {
+      removeItem(inventory, "fire_core", 1);
+      const dir = { x: mousePos.x - player.x, y: mousePos.y - player.y };
+      const fb = createFireball(
+        player.x,
+        player.y,
+        dir,
+        player.abilities.fireballLevel,
+        player.damageBuffMult,
+      );
+      if (fb) fireballs.push(fb);
+      fireballCooldown.value = 15;
+      renderInventory();
+      renderHotbar();
+    } else {
+      hud.showPickupMessage("Out of Fire Cores!");
+    }
+  }
+
+  let bowAiming = false;
+  if (player.weapon && player.weapon.type === "bow") {
+    bowAiming = aimHeld;
+    if (aimRelease) {
+      const arrowsLeft = countItem(inventory, "arrow");
+      if (arrowsLeft > 0) {
+        removeItem(inventory, "arrow", 1);
+        const dir = { x: mousePos.x - player.x, y: mousePos.y - player.y };
+        const a = createArrow(player.x, player.y, dir, player.damageBuffMult);
+        if (a) arrows.push(a);
+        renderInventory();
+        renderHotbar();
+      } else {
+        hud.showPickupMessage("Out of Arrows!");
+      }
+    }
+  }
+
+  if (player.abilities.fireOrb) {
+    updateOrbs(fireOrbs, player, zombies, player.abilities.fireOrbLevel, (z) =>
+      dropLoot(z, worldItems),
+    );
+  }
+
+  return { bowAiming, fireballCooldown: fireballCooldown.value };
+}

--- a/frontend/src/systems/collision-system.js
+++ b/frontend/src/systems/collision-system.js
@@ -1,0 +1,73 @@
+import { updateFireballs, updateExplosions } from "../spells.js";
+import { updateArrows } from "../entities/arrow.js";
+import { SEGMENT_SIZE } from "../game_logic.js";
+import { isColliding } from "../utils/geometry.js";
+import { addItem } from "../inventory.js";
+
+export function circleRectColliding(circle, rect, radius) {
+  const closestX = Math.max(rect.x, Math.min(circle.x, rect.x + rect.size));
+  const closestY = Math.max(rect.y, Math.min(circle.y, rect.y + rect.size));
+  const dx = circle.x - closestX;
+  const dy = circle.y - closestY;
+  return dx * dx + dy * dy < radius * radius;
+}
+
+export function checkAllCollisions({
+  player,
+  zombies,
+  arrows,
+  fireballs,
+  walls,
+  explosions,
+  worldItems,
+  inventory,
+  hud,
+  renderInventory,
+  renderHotbar,
+  dropLoot,
+  materialDrops,
+}) {
+  updateFireballs(fireballs, zombies, walls, explosions, (z) =>
+    dropLoot(z, worldItems),
+  );
+  updateExplosions(explosions);
+  updateArrows(
+    arrows,
+    zombies,
+    walls,
+    (z) => dropLoot(z, worldItems),
+    (w) =>
+      worldItems.push({
+        x: w.x + SEGMENT_SIZE / 2,
+        y: w.y + SEGMENT_SIZE / 2,
+        type: materialDrops[w.material],
+        count: 1,
+      }),
+  );
+
+  // handle player colliding with zombies
+  for (const z of zombies) {
+    if (
+      isColliding(z, player, 10) &&
+      player.damageCooldown <= 0 &&
+      z.attackCooldown <= 0
+    ) {
+      player.health--;
+      player.damageCooldown = 30;
+      z.attackCooldown = 30;
+    }
+  }
+
+  // handle player picking up world items
+  for (let i = worldItems.length - 1; i >= 0; i--) {
+    const it = worldItems[i];
+    if (isColliding(player, it, 10)) {
+      if (addItem(inventory, it.type, it.count)) {
+        worldItems.splice(i, 1);
+        hud.showPickupMessage(`Picked up ${it.type}`);
+        renderInventory();
+        renderHotbar();
+      }
+    }
+  }
+}

--- a/frontend/src/systems/rendering-system.js
+++ b/frontend/src/systems/rendering-system.js
@@ -1,0 +1,181 @@
+export function drawSprite(ctx, img, x, y, facing, size = 32) {
+  const angle = Math.atan2(facing.y, facing.x) - Math.PI / 2;
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.rotate(angle);
+  ctx.drawImage(img, -size / 2, -size / 2, size, size);
+  ctx.restore();
+}
+
+import { WALL_IMAGES } from "../walls.js";
+import { fireballStats, predictFireballEndpoint } from "../spells.js";
+import { predictArrowEndpoint } from "../entities/arrow.js";
+import { renderZombies } from "../entities/zombie.js";
+import { SEGMENT_SIZE } from "../game_logic.js";
+
+export function render(ctx, state) {
+  const {
+    walls,
+    containers,
+    spawnDoor,
+    player,
+    playerSprite,
+    fireZombieSprite,
+    zombieSprite,
+    fireOrbs,
+    hud,
+    inventory,
+    ITEM_IMAGES,
+    weapon,
+    worldItems,
+    arrows,
+    mousePos,
+    zombies,
+    activeSlot,
+    fireballs,
+    explosions,
+    bowAiming,
+    cardboardBoxImg,
+    countItem,
+  } = state;
+
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+  walls.forEach((w) => {
+    const img = WALL_IMAGES[w.material];
+    if (img && img.complete) {
+      ctx.globalAlpha = w.opened ? 0.5 : 1;
+      ctx.drawImage(img, w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
+      ctx.globalAlpha = 1;
+    } else {
+      ctx.fillStyle = "gray";
+      ctx.fillRect(w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
+    }
+    if (w.damageTimer > 0) {
+      ctx.fillStyle = "rgba(255,0,0,0.5)";
+      ctx.fillRect(w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
+    }
+    if (w.hp < w.maxHp) {
+      ctx.fillStyle = "red";
+      ctx.fillRect(w.x, w.y - 6, SEGMENT_SIZE, 4);
+      ctx.fillStyle = "lime";
+      ctx.fillRect(w.x, w.y - 6, (w.hp / w.maxHp) * SEGMENT_SIZE, 4);
+    }
+  });
+  containers.forEach((c) => {
+    ctx.globalAlpha = c.opened ? 0.5 : 1;
+    ctx.drawImage(cardboardBoxImg, c.x - 10, c.y - 10, 20, 20);
+    ctx.globalAlpha = 1;
+  });
+  if (spawnDoor) {
+    ctx.fillStyle = "brown";
+    ctx.fillRect(spawnDoor.x - 5, spawnDoor.y - 5, 10, 10);
+  }
+
+  drawSprite(ctx, playerSprite, player.x, player.y, player.facing);
+
+  if (player.abilities.fireOrb) {
+    ctx.fillStyle = "orange";
+    fireOrbs.forEach((o) => {
+      if (o.cooldown <= 0) {
+        ctx.beginPath();
+        ctx.arc(o.x, o.y, 5, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    });
+  }
+
+  if (player.swingTimer > 0) {
+    ctx.strokeStyle = "orange";
+    ctx.lineWidth = 3;
+    const startA = Math.atan2(player.facing.y, player.facing.x) - Math.PI / 4;
+    ctx.beginPath();
+    ctx.arc(player.x, player.y, 25, startA, startA + Math.PI / 2);
+    ctx.stroke();
+    ctx.lineWidth = 1;
+  }
+  hud.render(ctx, player, inventory, countItem);
+
+  if (weapon) {
+    const img = ITEM_IMAGES[weapon.type];
+    if (img) {
+      ctx.drawImage(img, weapon.x - 8, weapon.y - 8, 16, 16);
+    } else {
+      ctx.fillStyle = "orange";
+      ctx.beginPath();
+      ctx.arc(weapon.x, weapon.y, 6, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  ctx.fillStyle = "yellow";
+  worldItems.forEach((it) => {
+    ctx.beginPath();
+    ctx.arc(it.x, it.y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  ctx.fillStyle = "brown";
+  arrows.forEach((a) => {
+    ctx.beginPath();
+    ctx.arc(a.x, a.y, 2, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  if (bowAiming) {
+    const dir = { x: mousePos.x - player.x, y: mousePos.y - player.y };
+    const end = predictArrowEndpoint(player.x, player.y, dir, walls, zombies);
+    ctx.strokeStyle = "rgba(255,0,0,0.6)";
+    ctx.setLineDash([5, 5]);
+    ctx.beginPath();
+    ctx.moveTo(player.x, player.y);
+    ctx.lineTo(end.x, end.y);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.arc(end.x, end.y, 3, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
+  if (
+    activeSlot &&
+    activeSlot.item === "fireball_spell" &&
+    player.abilities.fireball
+  ) {
+    const dir = { x: mousePos.x - player.x, y: mousePos.y - player.y };
+    const end = predictFireballEndpoint(
+      player.x,
+      player.y,
+      dir,
+      walls,
+      zombies,
+    );
+    ctx.strokeStyle = "rgba(255,0,0,0.6)";
+    ctx.setLineDash([5, 5]);
+    ctx.beginPath();
+    ctx.moveTo(player.x, player.y);
+    ctx.lineTo(end.x, end.y);
+    ctx.stroke();
+    ctx.setLineDash([2, 4]);
+    const { radius } = fireballStats(player.abilities.fireballLevel);
+    ctx.beginPath();
+    ctx.arc(end.x, end.y, radius, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  ctx.fillStyle = "orange";
+  fireballs.forEach((fb) => {
+    ctx.beginPath();
+    ctx.arc(fb.x, fb.y, 4, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  ctx.fillStyle = "rgba(255,0,0,0.5)";
+  explosions.forEach((ex) => {
+    ctx.beginPath();
+    ctx.arc(ex.x, ex.y, ex.radius, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  renderZombies(ctx, zombies, zombieSprite, fireZombieSprite);
+}

--- a/frontend/tests/arrow.test.js
+++ b/frontend/tests/arrow.test.js
@@ -7,7 +7,7 @@ import {
 } from "../src/entities/arrow.js";
 
 // helper stubs
-import { circleRectColliding } from "../src/game_logic.js";
+import { circleRectColliding } from "../src/systems/collision-system.js";
 import { isColliding } from "../src/utils/geometry.js";
 
 test("createArrow normalizes direction", () => {

--- a/frontend/tests/game_logic.test.js
+++ b/frontend/tests/game_logic.test.js
@@ -1,13 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
-  circleRectColliding,
   SEGMENT_SIZE,
   spawnPlayer,
   createSpawnDoor,
   createContainer,
   spawnContainers,
 } from "../src/game_logic.js";
+import { circleRectColliding } from "../src/systems/collision-system.js";
 import { moveTowards, isColliding } from "../src/utils/geometry.js";
 import {
   createZombie,

--- a/frontend/tests/spells.test.js
+++ b/frontend/tests/spells.test.js
@@ -9,7 +9,7 @@ import {
 } from "../src/spells.js";
 
 // mocks for game_logic helpers
-import { circleRectColliding } from "../src/game_logic.js";
+import { circleRectColliding } from "../src/systems/collision-system.js";
 import { isColliding } from "../src/utils/geometry.js";
 
 test("createFireball normalizes direction", () => {


### PR DESCRIPTION
## Summary
- move rendering logic into rendering-system
- add ability system for projectile management
- centralize projectile and player collisions in collision-system
- call new systems from the game loop
- document new systems layout

## Testing
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_687032cd01108323a83b533c0113f8c3