### PR TITLE
Add websocket endpoint and game manager

### DIFF
--- a/backend/app/api/websocket_routes.py
+++ b/backend/app/api/websocket_routes.py
@@ -1,0 +1,23 @@
+"""WebSocket routes for real-time communication."""
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from ..game.manager import manager
+
+router = APIRouter()
+
+
+@router.websocket("/ws/game")
+async def game_ws(websocket: WebSocket) -> None:
+    """Handle a websocket connection from a game client."""
+
+    await websocket.accept()
+    player_id = str(id(websocket))
+    manager.add_player(player_id)
+    print(f"Player {player_id} connected")
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.remove_player(player_id)
+        print(f"Player {player_id} disconnected")

--- a/backend/app/game/manager.py
+++ b/backend/app/game/manager.py
@@ -1,0 +1,31 @@
+"""Holds the authoritative game state on the server."""
+
+from typing import Dict
+
+from .models import GameState, PlayerState
+
+
+class GameManager:
+    """Manage players and expose the current game state."""
+
+    def __init__(self) -> None:
+        self.state = GameState(players={})
+
+    def add_player(self, player_id: str) -> None:
+        """Add a new player to the game with default state."""
+
+        self.state.players[player_id] = PlayerState(x=0.0, y=0.0, facing="down")
+
+    def remove_player(self, player_id: str) -> None:
+        """Remove a player from the game if present."""
+
+        self.state.players.pop(player_id, None)
+
+    def get_game_state(self) -> GameState:
+        """Return the current game state."""
+
+        return self.state
+
+
+# Single global instance used by API routes
+manager = GameManager()

--- a/backend/app/game/models.py
+++ b/backend/app/game/models.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import Dict
+
+
+class PlayerState(BaseModel):
+    """State for a single connected player."""
+
+    x: float
+    y: float
+    facing: str
+
+
+class GameState(BaseModel):
+    """Container for the entire game world state."""
+
+    players: Dict[str, PlayerState] = {}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
 
-from .api import routes_health
+from .api import routes_health, websocket_routes
 
 app = FastAPI()
 
 app.include_router(routes_health.router)
+app.include_router(websocket_routes.router)

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_websocket_connection():
+    with client.websocket_connect("/ws/game"):
+        pass

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,10 @@ This project is split into separate frontend and backend components.
   Reusable math helpers like `moveTowards` and `isColliding` live in `frontend/src/utils/geometry.js`.
   UI elements such as the inventory, skill tree and HUD are implemented in separate modules under `frontend/src/components/`.
   Game systems such as rendering, abilities and collisions reside in `frontend/src/systems/` to keep the main loop minimal. The collision system manages all projectile interactions as well as player contacts with zombies and world items.
-- **Backend**: Python FastAPI service providing API endpoints. Initially exposes a simple health check and is prepared for future features like multiplayer or persistence.
+- **Backend**: Python FastAPI service providing API endpoints. It now exposes a
+  WebSocket endpoint at `/ws/game` and includes a lightweight `GameManager`
+  responsible for tracking connected players. The service began with a simple
+  health check but is structured for future realtime features.
 
 Both sides communicate via HTTP or WebSockets. The repository emphasizes clear separation of concerns and maintainable code.
 The gameplay state is managed by a `GameScene` class in `frontend/src/scenes/game-scene.js`. It owns the player, zombies and other world objects and exposes `update` and `render` methods used by `main.js`.


### PR DESCRIPTION
## Summary
- add basic player/game models
- provide a GameManager for holding game state
- expose `/ws/game` websocket endpoint
- document backend websocket in architecture docs
- test websocket connection

## Testing
- `npm test --prefix frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706c10507c8323baadb255ce4ca4a8