### PR TITLE
Add WebSocket player updates

### DIFF
--- a/backend/app/api/websocket_routes.py
+++ b/backend/app/api/websocket_routes.py
@@ -17,7 +17,8 @@ async def game_ws(websocket: WebSocket) -> None:
     print(f"Player {player_id} connected")
     try:
         while True:
-            await websocket.receive_text()
+            data = await websocket.receive_json()
+            manager.update_player_state(player_id, data)
     except WebSocketDisconnect:
         manager.remove_player(player_id)
         print(f"Player {player_id} disconnected")

--- a/backend/app/game/manager.py
+++ b/backend/app/game/manager.py
@@ -1,6 +1,6 @@
 """Holds the authoritative game state on the server."""
 
-from typing import Dict
+from typing import Any, Dict
 
 from .models import GameState, PlayerState
 
@@ -20,6 +20,33 @@ class GameManager:
         """Remove a player from the game if present."""
 
         self.state.players.pop(player_id, None)
+
+    def update_player_state(self, player_id: str, input_data: Dict[str, Any]) -> None:
+        """Update the player's state using the received input."""
+
+        player = self.state.players.get(player_id)
+        if not player:
+            return
+
+        speed = 5
+        if input_data.get("action") == "move":
+            direction = input_data.get("direction")
+            if direction == "left":
+                player.x -= speed
+            elif direction == "right":
+                player.x += speed
+            elif direction == "up":
+                player.y -= speed
+            elif direction == "down":
+                player.y += speed
+
+        facing_x = input_data.get("facingX")
+        facing_y = input_data.get("facingY")
+        if facing_x is not None and facing_y is not None:
+            if abs(facing_x) > abs(facing_y):
+                player.facing = "right" if facing_x > 0 else "left"
+            else:
+                player.facing = "down" if facing_y > 0 else "up"
 
     def get_game_state(self) -> GameState:
         """Return the current game state."""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 httpx
+websockets

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from fastapi.testclient import TestClient
 from app.main import app
+from app.game.manager import manager
 
 client = TestClient(app)
 
@@ -12,3 +13,17 @@ client = TestClient(app)
 def test_websocket_connection():
     with client.websocket_connect("/ws/game"):
         pass
+
+
+def test_update_player_state_via_websocket():
+    with client.websocket_connect("/ws/game") as ws:
+        player_id = next(iter(manager.state.players))
+        ws.send_json(
+            {"action": "move", "direction": "right", "facingX": 1, "facingY": 0}
+        )
+        import time
+
+        time.sleep(0.05)
+        player = manager.state.players[player_id]
+        assert player.x == 5
+        assert player.facing == "right"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,8 @@ This project is split into separate frontend and backend components.
   responsible for tracking connected players. The service began with a simple
   health check but is structured for future realtime features. The
   **frontend** connects to this WebSocket when a `GameScene` is created and
-  forwards player input messages over the socket.
+  forwards player input messages over the socket. The server interprets these
+  messages using the `GameManager` to update each player's authoritative state.
 
 Both sides communicate via HTTP or WebSockets. The repository emphasizes clear separation of concerns and maintainable code.
 The gameplay state is managed by a `GameScene` class in `frontend/src/scenes/game-scene.js`. It owns the player, zombies and other world objects and exposes `update` and `render` methods used by `main.js`.


### PR DESCRIPTION
## Summary
- add `websockets` dependency
- implement `update_player_state` in backend `GameManager`
- process websocket messages and apply player updates
- test websocket player update logic
- document authoritative movement in architecture docs

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68708e4785f48323869489b871126574