### PR TITLE
Implement server broadcast game loop

### DIFF
--- a/backend/app/api/websocket_routes.py
+++ b/backend/app/api/websocket_routes.py
@@ -13,7 +13,7 @@ async def game_ws(websocket: WebSocket) -> None:
 
     await websocket.accept()
     player_id = str(id(websocket))
-    manager.add_player(player_id)
+    manager.add_player(player_id, websocket)
     print(f"Player {player_id} connected")
     try:
         while True:

--- a/backend/app/game/manager.py
+++ b/backend/app/game/manager.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict
 
+from fastapi import WebSocket
+
 from .models import GameState, PlayerState
 
 
@@ -10,16 +12,20 @@ class GameManager:
 
     def __init__(self) -> None:
         self.state = GameState(players={})
+        # Track active WebSocket connections for broadcasting state
+        self.connections: Dict[str, WebSocket] = {}
 
-    def add_player(self, player_id: str) -> None:
-        """Add a new player to the game with default state."""
+    def add_player(self, player_id: str, websocket: WebSocket) -> None:
+        """Add a new player to the game with default state and store connection."""
 
         self.state.players[player_id] = PlayerState(x=0.0, y=0.0, facing="down")
+        self.connections[player_id] = websocket
 
     def remove_player(self, player_id: str) -> None:
-        """Remove a player from the game if present."""
+        """Remove a player from the game if present and drop connection."""
 
         self.state.players.pop(player_id, None)
+        self.connections.pop(player_id, None)
 
     def update_player_state(self, player_id: str, input_data: Dict[str, Any]) -> None:
         """Update the player's state using the received input."""
@@ -52,6 +58,11 @@ class GameManager:
         """Return the current game state."""
 
         return self.state
+
+    def get_connections(self) -> Dict[str, WebSocket]:
+        """Return the current active websocket connections."""
+
+        return self.connections
 
 
 # Single global instance used by API routes

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,40 @@
+"""FastAPI application with a background game loop."""
+
+import asyncio
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from .api import routes_health, websocket_routes
+from .game.manager import manager
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Start background tasks when the application starts."""
+
+    task = asyncio.create_task(game_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+async def game_loop() -> None:
+    """Continuously broadcast the authoritative game state to all clients."""
+
+    while True:
+        state = manager.get_game_state().dict()
+        for websocket in list(manager.get_connections().values()):
+            try:
+                await websocket.send_json(state)
+            except Exception:
+                # Ignore send errors; connection cleanup happens elsewhere
+                pass
+        await asyncio.sleep(1 / 60)
+
 
 app.include_router(routes_health.router)
 app.include_router(websocket_routes.router)

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -6,10 +6,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from fastapi.testclient import TestClient
 from app.main import app
 
-client = TestClient(app)
-
 
 def test_health_check():
-    response = client.get("/health")
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    with TestClient(app) as client:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -7,23 +7,40 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.game.manager import manager
 
-client = TestClient(app)
-
 
 def test_websocket_connection():
-    with client.websocket_connect("/ws/game"):
-        pass
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/game"):
+            pass
 
 
 def test_update_player_state_via_websocket():
-    with client.websocket_connect("/ws/game") as ws:
-        player_id = next(iter(manager.state.players))
-        ws.send_json(
-            {"action": "move", "direction": "right", "facingX": 1, "facingY": 0}
-        )
-        import time
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/game") as ws:
+            player_id = next(iter(manager.state.players))
+            ws.send_json(
+                {"action": "move", "direction": "right", "facingX": 1, "facingY": 0}
+            )
+            import time
 
-        time.sleep(0.05)
-        player = manager.state.players[player_id]
-        assert player.x == 5
-        assert player.facing == "right"
+            time.sleep(0.05)
+            player = manager.state.players[player_id]
+            assert player.x == 5
+            assert player.facing == "right"
+
+
+def test_game_state_broadcast():
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws/game"):
+            player_id = next(iter(manager.state.players))
+            ws_obj = manager.connections[player_id]
+
+            from unittest.mock import AsyncMock
+            import time
+
+            original_send = ws_obj.send_json
+            send_spy = AsyncMock(wraps=original_send)
+            ws_obj.send_json = send_spy
+
+            time.sleep(0.2)
+            assert send_spy.called

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,9 @@ This project is split into separate frontend and backend components.
   **frontend** connects to this WebSocket when a `GameScene` is created and
   forwards player input messages over the socket. The server interprets these
   messages using the `GameManager` to update each player's authoritative state.
+  A background task started on application startup runs a server game loop that
+  broadcasts the complete game state to all connected clients roughly 60 times
+  per second.
 
 Both sides communicate via HTTP or WebSockets. The repository emphasizes clear separation of concerns and maintainable code.
 The gameplay state is managed by a `GameScene` class in `frontend/src/scenes/game-scene.js`. It owns the player, zombies and other world objects and exposes `update` and `render` methods used by `main.js`.


### PR DESCRIPTION
## Summary
- track websocket connections in GameManager
- add FastAPI lifespan game loop broadcasting state
- broadcast state on each tick to all connected clients
- test websocket broadcasts and startup
- document server game loop in architecture docs

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68709656286483238c77726f12bb37bd