### PR TITLE
Fix player facing and collision

### DIFF
--- a/backend/app/game/manager.py
+++ b/backend/app/game/manager.py
@@ -18,7 +18,9 @@ class GameManager:
     def add_player(self, player_id: str, websocket: WebSocket) -> None:
         """Add a new player to the game with default state and store connection."""
 
-        self.state.players[player_id] = PlayerState(x=0.0, y=0.0, facing="down")
+        self.state.players[player_id] = PlayerState(
+            x=0.0, y=0.0, facing_x=0.0, facing_y=1.0
+        )
         self.connections[player_id] = websocket
 
     def remove_player(self, player_id: str) -> None:
@@ -57,10 +59,8 @@ class GameManager:
         facing_x = input_data.get("facingX")
         facing_y = input_data.get("facingY")
         if facing_x is not None and facing_y is not None:
-            if abs(facing_x) > abs(facing_y):
-                player.facing = "right" if facing_x > 0 else "left"
-            else:
-                player.facing = "down" if facing_y > 0 else "up"
+            player.facing_x = float(facing_x)
+            player.facing_y = float(facing_y)
 
     def get_game_state(self) -> GameState:
         """Return the current game state."""

--- a/backend/app/game/models.py
+++ b/backend/app/game/models.py
@@ -7,7 +7,8 @@ class PlayerState(BaseModel):
 
     x: float
     y: float
-    facing: str
+    facing_x: float
+    facing_y: float
 
 
 class GameState(BaseModel):

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -26,7 +26,8 @@ def test_update_player_state_via_websocket():
             time.sleep(0.05)
             player = manager.state.players[player_id]
             assert player.x == 2
-            assert player.facing == "right"
+            assert player.facing_x == 1
+            assert player.facing_y == 0
 
 
 def test_game_state_broadcast():

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,8 @@ This project is split into separate frontend and backend components.
   forwards player input messages over the socket. Input includes `moveX` and
   `moveY` deltas along with the mouse facing vector. The server interprets these
   values using the `GameManager` to update each player's authoritative state.
+  Facing is kept as normalized `facing_x` and `facing_y` numbers so the player
+  can point in any direction.
   A background task started on application startup runs a server game loop that
   broadcasts the complete game state to all connected clients roughly 60 times
   per second.

--- a/frontend/src/scenes/game-scene.js
+++ b/frontend/src/scenes/game-scene.js
@@ -290,15 +290,12 @@ export class GameScene {
       if (!serverPlayer) return;
       this.player.x = serverPlayer.x;
       this.player.y = serverPlayer.y;
-      const map = {
-        up: { x: 0, y: -1 },
-        down: { x: 0, y: 1 },
-        left: { x: -1, y: 0 },
-        right: { x: 1, y: 0 },
-      };
-      if (map[serverPlayer.facing]) {
-        this.player.facing.x = map[serverPlayer.facing].x;
-        this.player.facing.y = map[serverPlayer.facing].y;
+      if (
+        typeof serverPlayer.facing_x === "number" &&
+        typeof serverPlayer.facing_y === "number"
+      ) {
+        this.player.facing.x = serverPlayer.facing_x;
+        this.player.facing.y = serverPlayer.facing_y;
       }
     } catch (err) {
       console.error("Failed to parse server state", err);
@@ -646,6 +643,17 @@ export class GameScene {
     if (this.keys["arrowdown"] || this.keys["s"]) moveY += this.player.speed;
     if (this.keys["arrowleft"] || this.keys["a"]) moveX -= this.player.speed;
     if (this.keys["arrowright"] || this.keys["d"]) moveX += this.player.speed;
+
+    let newX = this.player.x + moveX;
+    let newY = this.player.y + moveY;
+    newX = Math.max(10, Math.min(this.canvas.width - 10, newX));
+    newY = Math.max(10, Math.min(this.canvas.height - 10, newY));
+    if (
+      this.walls.some((w) => circleRectColliding({ x: newX, y: newY }, w, 10))
+    ) {
+      moveX = 0;
+      moveY = 0;
+    }
 
     const toMouseX = this.mousePos.x - this.player.x;
     const toMouseY = this.mousePos.y - this.player.y;


### PR DESCRIPTION
## Summary
- keep server player state with a floating `facing_x` and `facing_y`
- parse new facing values on the client
- prevent sending movement that collides with obstacles
- update architecture docs
- adjust websocket tests for new fields

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870a1d7899c8323b09b20165ba4568d