### PR TITLE
Add drag-and-drop support for inventory

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,7 @@ This project is split into separate frontend and backend components.
   Zombie behavior resides in `frontend/src/entities/zombie.js` to keep AI code modular.
   Reusable math helpers like `moveTowards` and `isColliding` live in `frontend/src/utils/geometry.js`.
   UI elements such as the inventory, skill tree and HUD are implemented in separate modules under `frontend/src/components/`.
+  Inventory and hotbar slots support drag-and-drop to swap or move items using the same logic as clicking.
   Game systems such as rendering, abilities and collisions reside in `frontend/src/systems/` to keep the main loop minimal. The collision system manages all projectile interactions as well as player contacts with zombies and world items.
 - **Backend**: Python FastAPI service providing API endpoints. It now exposes a
   WebSocket endpoint at `/ws/game` and includes a lightweight `GameManager`

--- a/frontend/src/components/inventory-ui.js
+++ b/frontend/src/components/inventory-ui.js
@@ -40,6 +40,7 @@ export function createInventoryUI({
     inventoryGrid.innerHTML = "";
     inventory.slots.forEach((slot, i) => {
       const div = document.createElement("div");
+      div.draggable = true;
       div.dataset.index = i;
       Object.assign(div.style, {
         width: "40px",
@@ -124,6 +125,34 @@ export function createInventoryUI({
           getItemCooldown,
         );
       });
+      div.addEventListener("dragstart", () => {
+        selectedSlot = { type: "inventory", index: i };
+      });
+      div.addEventListener("dragover", (e) => e.preventDefault());
+      div.addEventListener("drop", (e) => {
+        e.preventDefault();
+        if (!selectedSlot) return;
+        if (selectedSlot.type === "inventory") {
+          moveItem(inventory, selectedSlot.index, i);
+        } else {
+          swapInventoryHotbar(inventory, i, selectedSlot.index);
+        }
+        selectedSlot = null;
+        renderInventory(
+          inventory,
+          player,
+          fireballCooldown,
+          itemIcons,
+          getItemCooldown,
+        );
+        renderHotbar(
+          inventory,
+          player,
+          fireballCooldown,
+          itemIcons,
+          getItemCooldown,
+        );
+      });
       div.addEventListener("contextmenu", (e) => {
         e.preventDefault();
         const slot = inventory.slots[i];
@@ -162,6 +191,7 @@ export function createInventoryUI({
     hotbarDiv.innerHTML = "";
     inventory.hotbar.forEach((slot, i) => {
       const div = document.createElement("div");
+      div.draggable = true;
       Object.assign(div.style, {
         width: "40px",
         height: "40px",
@@ -232,6 +262,34 @@ export function createInventoryUI({
           }
           selectedSlot = null;
         }
+        renderInventory(
+          inventory,
+          player,
+          fireballCooldown,
+          itemIcons,
+          getItemCooldown,
+        );
+        renderHotbar(
+          inventory,
+          player,
+          fireballCooldown,
+          itemIcons,
+          getItemCooldown,
+        );
+      });
+      div.addEventListener("dragstart", () => {
+        selectedSlot = { type: "hotbar", index: i };
+      });
+      div.addEventListener("dragover", (e) => e.preventDefault());
+      div.addEventListener("drop", (e) => {
+        e.preventDefault();
+        if (!selectedSlot) return;
+        if (selectedSlot.type === "hotbar") {
+          swapHotbar(inventory, selectedSlot.index, i);
+        } else {
+          swapInventoryHotbar(inventory, selectedSlot.index, i);
+        }
+        selectedSlot = null;
         renderInventory(
           inventory,
           player,


### PR DESCRIPTION
## Summary
- allow inventory and hotbar slots to be draggable
- handle drag events to swap/move items between slots
- document new drag-and-drop capability in the architecture overview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870aa22291c8323b0ce10916ac6ec96