### PR TITLE
Add multi-session GameManager with lobby creation

### DIFF
--- a/backend/app/api/routes_game.py
+++ b/backend/app/api/routes_game.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from ..game.manager import manager
+
+router = APIRouter(prefix="/api")
+
+
+@router.post("/games")
+async def create_game():
+    """Create a new game session and return its ID."""
+
+    game_id = manager.create_game_session()
+    return {"gameId": game_id}

--- a/backend/app/api/websocket_routes.py
+++ b/backend/app/api/websocket_routes.py
@@ -7,18 +7,23 @@ from ..game.manager import manager
 router = APIRouter()
 
 
-@router.websocket("/ws/game")
-async def game_ws(websocket: WebSocket) -> None:
-    """Handle a websocket connection from a game client."""
+@router.websocket("/ws/game/{game_id}")
+async def game_ws(websocket: WebSocket, game_id: str) -> None:
+    """Handle a websocket connection for the provided game session."""
+
+    session = manager.get_session(game_id)
+    if not session:
+        await websocket.close()
+        return
 
     await websocket.accept()
-    player_id = manager.add_player(websocket)
+    player_id = session.add_player(websocket)
     await websocket.send_json({"type": "welcome", "playerId": player_id})
-    print(f"Player {player_id} connected")
+    print(f"Player {player_id} connected to game {game_id}")
     try:
         while True:
             data = await websocket.receive_json()
-            manager.update_player_state(player_id, data)
+            session.update_player_state(player_id, data)
     except WebSocketDisconnect:
-        manager.remove_player(player_id)
-        print(f"Player {player_id} disconnected")
+        session.remove_player(player_id)
+        print(f"Player {player_id} disconnected from game {game_id}")

--- a/backend/tests/test_game_routes.py
+++ b/backend/tests/test_game_routes.py
@@ -7,10 +7,13 @@ sys.path.insert(
 
 from fastapi.testclient import TestClient
 from app.main import app
+from app.game.manager import manager
 
 
-def test_health_check():
+def test_create_game_endpoint():
     with TestClient(app) as client:
-        response = client.get("/health")
+        response = client.post("/api/games")
         assert response.status_code == 200
-        assert response.json() == {"status": "ok"}
+        data = response.json()
+        assert "gameId" in data
+        assert manager.get_session(data["gameId"]) is not None

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,11 +12,12 @@ This project is split into separate frontend and backend components.
   accept drops.
   Game systems such as rendering, abilities and collisions reside in `frontend/src/systems/` to keep the main loop minimal. The collision system manages all projectile interactions as well as player contacts with zombies and world items.
 - **Backend**: Python FastAPI service providing API endpoints. It now exposes a
-  WebSocket endpoint at `/ws/game` and includes a lightweight `GameManager`
-  responsible for tracking connected players. When a client connects the
-  manager assigns it a UUID and immediately sends a "welcome" message
-  containing this ID. The service began with a simple
-  health check but is structured for future realtime features. The
+  WebSocket endpoint at `/ws/game/{game_id}` and includes a `GameManager`
+  capable of creating multiple `GameSession` objects. Each session tracks its
+  own players and connections. When a client connects the session assigns it a
+  UUID and immediately sends a "welcome" message containing this ID. A new game
+  can be created via the `/api/games` HTTP endpoint. The service began with a
+  simple health check but is structured for future realtime features. The
   **frontend** connects to this WebSocket when a `GameScene` is created and
   forwards player input messages over the socket. Input includes `moveX` and
   `moveY` deltas along with the mouse facing vector. The server interprets these


### PR DESCRIPTION
## Summary
- allow managing multiple `GameSession`s via new `GameManager`
- create `/api/games` endpoint for starting games
- update WebSocket path to `/ws/game/{game_id}`
- broadcast state per session
- document backend architecture changes
- add tests for new behavior

## Testing
- `pip install -r backend/requirements.txt --quiet`
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6871dbf50a74832396a36f11ddfc07cf