### PR TITLE
Implement lobby UI with dynamic WebSocket connection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,10 +18,14 @@ This project is split into separate frontend and backend components.
   UUID and immediately sends a "welcome" message containing this ID. A new game
   can be created via the `/api/games` HTTP endpoint. The service began with a
   simple health check but is structured for future realtime features. The
-  **frontend** connects to this WebSocket when a `GameScene` is created and
-  forwards player input messages over the socket. Input includes `moveX` and
-  `moveY` deltas along with the mouse facing vector. The server interprets these
-  values using the `GameManager` to update each player's authoritative state.
+  Clients first see a lobby screen that can create or join a session using the
+  `/api/games` endpoint. The lobby passes the chosen `gameId` to a
+  `startGame(gameId)` function which instantiates `GameScene` and connects to a
+  WebSocket at `ws://${hostname}:8000/ws/game/${gameId}`. Once connected the
+  lobby hides and the game canvas becomes active. The game scene then forwards
+  player input messages over the socket. Input includes `moveX` and `moveY`
+  deltas along with the mouse facing vector. The server interprets these values
+  using the `GameManager` to update each player's authoritative state.
   Facing is kept as normalized `facing_x` and `facing_y` numbers so the player
   can point in any direction.
   A background task started on application startup runs a server game loop that

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,6 +36,23 @@
     </style>
   </head>
   <body>
+    <div
+      id="lobby"
+      style="
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 1;
+      "
+    >
+      <button id="createGameBtn">Create Game</button>
+      <input id="gameIdInput" placeholder="Game ID" />
+      <button id="joinGameBtn">Join Game</button>
+    </div>
     <canvas
       id="gameCanvas"
       style="display: block; width: 100vw; height: 100vh"

--- a/frontend/src/components/lobby.js
+++ b/frontend/src/components/lobby.js
@@ -1,0 +1,32 @@
+/**
+ * Setup lobby UI for creating or joining a game.
+ *
+ * @param {(id: string) => void} startGame - Callback invoked when the lobby
+ *   acquires a valid game ID.
+ * @returns {void}
+ */
+export function setupLobby(startGame) {
+  const lobby = document.getElementById("lobby");
+  const createBtn = document.getElementById("createGameBtn");
+  const joinBtn = document.getElementById("joinGameBtn");
+  const idInput = document.getElementById("gameIdInput");
+
+  createBtn?.addEventListener("click", async () => {
+    try {
+      const res = await fetch("/api/games", { method: "POST" });
+      if (!res.ok) return;
+      const data = await res.json();
+      lobby.style.display = "none";
+      startGame(data.gameId);
+    } catch (err) {
+      console.error("Failed to create game", err);
+    }
+  });
+
+  joinBtn?.addEventListener("click", () => {
+    const id = idInput?.value.trim();
+    if (!id) return;
+    lobby.style.display = "none";
+    startGame(id);
+  });
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,8 @@
 import { GameScene } from "./scenes/game-scene.js";
+import { setupLobby } from "./components/lobby.js";
 
-const scene = new GameScene();
+let SceneClass = GameScene;
+let scene;
 
 function gameLoop() {
   scene.update();
@@ -8,13 +10,37 @@ function gameLoop() {
   requestAnimationFrame(gameLoop);
 }
 
-window.addEventListener("resize", () => scene.resizeCanvas());
-window.addEventListener("keydown", (e) => scene.handleKeyDown(e));
-window.addEventListener("keyup", (e) => scene.handleKeyUp(e));
-scene.canvas.addEventListener("mousemove", (e) => scene.handleMouseMove(e));
-scene.canvas.addEventListener("mousedown", (e) => scene.handleMouseDown(e));
-scene.canvas.addEventListener("mouseup", (e) => scene.handleMouseUp(e));
-scene.canvas.addEventListener("contextmenu", (e) => e.preventDefault());
+/**
+ * Start a new game connected to the given session.
+ *
+ * @param {string} gameId - Identifier of the game session.
+ * @returns {void}
+ */
+export function startGame(gameId) {
+  scene = new SceneClass();
+  const wsUrl = `ws://${window.location.hostname}:8000/ws/game/${gameId}`;
+  scene.initWebSocket(wsUrl);
 
-scene.startGame();
-requestAnimationFrame(gameLoop);
+  window.addEventListener("resize", () => scene.resizeCanvas());
+  window.addEventListener("keydown", (e) => scene.handleKeyDown(e));
+  window.addEventListener("keyup", (e) => scene.handleKeyUp(e));
+  scene.canvas.addEventListener("mousemove", (e) => scene.handleMouseMove(e));
+  scene.canvas.addEventListener("mousedown", (e) => scene.handleMouseDown(e));
+  scene.canvas.addEventListener("mouseup", (e) => scene.handleMouseUp(e));
+  scene.canvas.addEventListener("contextmenu", (e) => e.preventDefault());
+
+  scene.startGame();
+  requestAnimationFrame(gameLoop);
+}
+
+/**
+ * Override the internal GameScene constructor for testing purposes.
+ *
+ * @param {typeof GameScene} cls - Replacement class.
+ * @returns {void}
+ */
+export function __setGameSceneClass(cls) {
+  SceneClass = cls;
+}
+
+setupLobby(startGame);

--- a/frontend/src/scenes/game-scene.js
+++ b/frontend/src/scenes/game-scene.js
@@ -243,7 +243,6 @@ export class GameScene {
       this.startGame();
     });
     this.resizeCanvas();
-    this.initWebSocket();
   }
 
   /**
@@ -259,11 +258,11 @@ export class GameScene {
   /**
    * Establish a WebSocket connection to the backend.
    *
-   * Logs connection lifecycle events for debugging.
+   * @param {string} url - WebSocket endpoint to connect to.
    * @returns {void}
    */
-  initWebSocket() {
-    this.ws = new WebSocket("ws://localhost:8000/ws/game");
+  initWebSocket(url) {
+    this.ws = new WebSocket(url);
     this.ws.addEventListener("open", () => {
       console.log("Connected to game WebSocket");
     });

--- a/frontend/tests/lobby.test.js
+++ b/frontend/tests/lobby.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+
+// Patch GameScene before importing startGame
+let capturedUrl = null;
+class FakeScene {
+  constructor() {
+    this.canvas = document.createElement("canvas");
+  }
+  initWebSocket(url) {
+    capturedUrl = url;
+  }
+  startGame() {}
+  update() {}
+  render() {}
+  handleKeyDown() {}
+  handleKeyUp() {}
+  handleMouseMove() {}
+  handleMouseDown() {}
+  handleMouseUp() {}
+  resizeCanvas() {}
+}
+
+const dom = new JSDOM("<!DOCTYPE html><body></body>");
+global.document = dom.window.document;
+global.window = dom.window;
+global.window.requestAnimationFrame = () => {};
+global.requestAnimationFrame = () => {};
+
+const main = await import("../src/main.js");
+main.__setGameSceneClass(FakeScene);
+const { startGame } = main;
+
+test("startGame constructs websocket URL with gameId", () => {
+  startGame("abc123");
+  assert.ok(capturedUrl.endsWith("/abc123"));
+});


### PR DESCRIPTION
## Summary
- add lobby overlay with create/join controls
- handle lobby actions in new `setupLobby` component
- update `GameScene` to accept WebSocket URL
- export `startGame` and helper from `main.js`
- test `startGame` connection logic
- document lobby flow in architecture docs

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e1ad32448323a1e34ffdb50941cb