### PR TITLE
Align frontend create game request with backend route

### DIFF
--- a/backend/app/game/manager.py
+++ b/backend/app/game/manager.py
@@ -38,9 +38,7 @@ class GameSession:
         self.state.players.pop(player_id, None)
         self.connections.pop(player_id, None)
 
-    def update_player_state(
-        self, player_id: str, input_data: Dict[str, Any]
-    ) -> None:
+    def update_player_state(self, player_id: str, input_data: Dict[str, Any]) -> None:
         """Update the player's state using the received input."""
 
         player = self.state.players.get(player_id)

--- a/backend/tests/test_game_routes.py
+++ b/backend/tests/test_game_routes.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fastapi.testclient import TestClient
 from app.main import app

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fastapi.testclient import TestClient
 from app.main import app

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fastapi.testclient import TestClient
 from app.main import app

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,10 +16,11 @@ This project is split into separate frontend and backend components.
   capable of creating multiple `GameSession` objects. Each session tracks its
   own players and connections. When a client connects the session assigns it a
   UUID and immediately sends a "welcome" message containing this ID. A new game
-  can be created via the `/api/games` HTTP endpoint. The service began with a
-  simple health check but is structured for future realtime features. The
-  Clients first see a lobby screen that can create or join a session using the
-  `/api/games` endpoint. The lobby passes the chosen `gameId` to a
+  can be created via the `http://${hostname}:8000/api/games` HTTP endpoint. The
+  service began with a simple health check but is structured for future
+  realtime features. The Clients first see a lobby screen that can create or
+  join a session using the same `http://${hostname}:8000/api/games` endpoint.
+  The lobby passes the chosen `gameId` to a
   `startGame(gameId)` function which instantiates `GameScene` and connects to a
   WebSocket at `ws://${hostname}:8000/ws/game/${gameId}`. Once connected the
   lobby hides and the game canvas becomes active. The game scene then forwards

--- a/frontend/src/components/lobby.js
+++ b/frontend/src/components/lobby.js
@@ -13,7 +13,8 @@ export function setupLobby(startGame) {
 
   createBtn?.addEventListener("click", async () => {
     try {
-      const res = await fetch("/api/games", { method: "POST" });
+      const apiUrl = `http://${window.location.hostname}:8000/api/games`;
+      const res = await fetch(apiUrl, { method: "POST" });
       if (!res.ok) return;
       const data = await res.json();
       lobby.style.display = "none";


### PR DESCRIPTION
## Summary
- call backend on port 8000 when creating a game
- document full API URL in architecture docs
- format backend files with `black`

## Testing
- `npm test --prefix frontend`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_6871e736d5988323891ef17a94c48fb9