### PR TITLE
Fix CORS issue between dev servers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@
 import asyncio
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .api import routes_health, websocket_routes, routes_game
 from .game.manager import manager
@@ -20,6 +21,15 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+origins = ["http://localhost:3000"]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 async def game_loop() -> None:

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_cors_headers_on_post():
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/games",
+            headers={"Origin": "http://localhost:3000"},
+        )
+        assert response.status_code == 200
+        assert (
+            response.headers.get("access-control-allow-origin")
+            == "http://localhost:3000"
+        )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,8 @@ This project is split into separate frontend and backend components.
   UUID and immediately sends a "welcome" message containing this ID. A new game
   can be created via the `http://${hostname}:8000/api/games` HTTP endpoint. The
   service began with a simple health check but is structured for future
-  realtime features. The Clients first see a lobby screen that can create or
+  realtime features. During development the backend enables CORS for
+  `http://localhost:3000` so the Vite server can call the API. The Clients first see a lobby screen that can create or
   join a session using the same `http://${hostname}:8000/api/games` endpoint.
   The lobby passes the chosen `gameId` to a
   `startGame(gameId)` function which instantiates `GameScene` and connects to a


### PR DESCRIPTION
## Summary
- allow CORS requests from `http://localhost:3000`
- document dev CORS in architecture docs
- test that API responses include CORS headers

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ea5ebda883238451fd3b172ad2da