### PR TITLE
Fix start screen covering gameplay

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ This project is split into separate frontend and backend components.
   `startGame(gameId)` function which constructs a `GameScene`, attaches keyboard
   event listeners, and connects to a WebSocket at
   `ws://${hostname}:8000/ws/game/${gameId}`. Once connected the lobby hides and
-  the game canvas becomes active. The scene forwards player input messages over
+  the start menu overlay is removed so the game canvas becomes active. The scene forwards player input messages over
   the socket such as `moveX` and `moveY` deltas. The server interprets these
   values using the `GameManager` to update each player's authoritative state.
   Facing is kept as normalized `facing_x` and `facing_y` numbers so the player

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -21,6 +21,10 @@ export function startGame(gameId) {
   const wsUrl = `ws://${window.location.hostname}:8000/ws/game/${gameId}`;
   scene.initWebSocket(wsUrl);
 
+  // Hide splash screen so the canvas is visible once the session starts
+  const menu = document.getElementById("mainMenu");
+  if (menu) menu.style.display = "none";
+
   window.addEventListener("resize", () => scene.resizeCanvas());
   window.addEventListener("keydown", (e) => scene.handleKeyDown(e));
   window.addEventListener("keyup", (e) => scene.handleKeyUp(e));

--- a/frontend/tests/lobby.test.js
+++ b/frontend/tests/lobby.test.js
@@ -36,3 +36,11 @@ test("startGame constructs websocket URL with gameId", () => {
   startGame("abc123");
   assert.ok(capturedUrl.endsWith("/abc123"));
 });
+
+test("startGame hides the main menu if present", () => {
+  const menu = document.createElement("div");
+  menu.id = "mainMenu";
+  document.body.appendChild(menu);
+  startGame("test-id");
+  assert.strictEqual(menu.style.display, "none");
+});


### PR DESCRIPTION
## Summary
- hide the main menu once a game starts
- mention the start menu overlay in documentation
- test that `startGame()` hides the main menu

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f853a75883238cb68666d04be0bc