### PR TITLE
Migrate world generation to server

### DIFF
--- a/backend/app/game/manager.py
+++ b/backend/app/game/manager.py
@@ -14,9 +14,12 @@ class GameSession:
 
     def __init__(self) -> None:
         self.state = GameState(players={})
-        walls, zombies, door = generate_world(self.state.width, self.state.height)
+        walls, zombies, containers, door = generate_world(
+            self.state.width, self.state.height
+        )
         self.state.walls = walls
         self.state.zombies = zombies
+        self.state.containers = containers
         self.spawn_door = door
         # Track active WebSocket connections for broadcasting state
         self.connections: Dict[str, WebSocket] = {}

--- a/backend/app/game/models.py
+++ b/backend/app/game/models.py
@@ -1,7 +1,55 @@
 """Pydantic models describing the authoritative world state."""
 
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
 from pydantic import BaseModel
-from typing import Dict, List
+
+# ---------------------------------------------------------------------------
+# Item definitions
+# ---------------------------------------------------------------------------
+
+CONSUMABLE_ITEMS = {"medkit", "mutation_serum_fire"}
+ITEM_IDS = [
+    "core",
+    "flesh",
+    "teeth",
+    "zombie_essence",
+    "elemental_potion",
+    "transformation_syringe",
+    "fire_core",
+    "mutation_serum_fire",
+    "fireball_spell",
+    "fire_orb_skill",
+    "phoenix_revival_skill",
+    "baseball_bat",
+    "medkit",
+    "wood",
+    "bow",
+    "arrow",
+    "scrap_metal",
+    "duct_tape",
+    "nails",
+    "plastic_fragments",
+    "wood_planks",
+    "steel_plates",
+    "hammer",
+    "crowbar",
+    "axe",
+    "reinforced_axe",
+    "wood_barricade",
+]
+
+# ---------------------------------------------------------------------------
+# Wall definitions
+# ---------------------------------------------------------------------------
+
+WALL_MATERIALS = {
+    "steel": {"hp": 30},
+    "wood": {"hp": 20},
+    "plastic": {"hp": 10},
+}
 
 
 class WallState(BaseModel):
@@ -11,6 +59,18 @@ class WallState(BaseModel):
     y: float
     size: int
     material: str
+    hp: int
+    max_hp: int
+    damage_timer: int = 0
+    opened: bool = False
+    item: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Zombie definitions
+# ---------------------------------------------------------------------------
+
+ZOMBIE_MAX_HEALTH = 2
 
 
 class ZombieState(BaseModel):
@@ -18,8 +78,32 @@ class ZombieState(BaseModel):
 
     x: float
     y: float
-    facing_x: float
-    facing_y: float
+    facing_x: float = 0.0
+    facing_y: float = 1.0
+    triggered: bool = False
+    dest: Optional[Dict[str, float]] = None
+    idle_timer: int = 0
+    wander_angle: float = 0.0
+    wander_timer: int = 0
+    health: int = ZOMBIE_MAX_HEALTH
+    attack_cooldown: int = 0
+    variant: str = "normal"
+
+
+# ---------------------------------------------------------------------------
+# Player definitions
+# ---------------------------------------------------------------------------
+
+PLAYER_MAX_HEALTH = 10
+
+
+class PlayerAbilities(BaseModel):
+    fireball: bool = False
+    fireballLevel: int = 0
+    fireOrb: bool = False
+    fireOrbLevel: int = 0
+    phoenixRevival: bool = False
+    phoenixRevivalLevel: int = 0
 
 
 class PlayerState(BaseModel):
@@ -27,8 +111,40 @@ class PlayerState(BaseModel):
 
     x: float
     y: float
-    facing_x: float
-    facing_y: float
+    facing_x: float = 1.0
+    facing_y: float = 0.0
+    speed: float = 2.0
+    health: int = PLAYER_MAX_HEALTH
+    damage_cooldown: int = 0
+    weapon: Optional[str] = None
+    swing_timer: int = 0
+    abilities: PlayerAbilities = PlayerAbilities()
+    fire_mutation_points: int = 0
+    phoenix_cooldown: int = 0
+    damage_buff_timer: int = 0
+    damage_buff_mult: float = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Container definitions
+# ---------------------------------------------------------------------------
+
+CONTAINER_LOOT = ["scrap_metal", "duct_tape", "nails", "medkit"]
+
+
+class ContainerState(BaseModel):
+    """Lootable container such as a cardboard box."""
+
+    x: float
+    y: float
+    opened: bool = False
+    item: Optional[str] = None
+    type: str = "cardboard_box"
+
+
+# ---------------------------------------------------------------------------
+# Game state container
+# ---------------------------------------------------------------------------
 
 
 class GameState(BaseModel):
@@ -37,5 +153,6 @@ class GameState(BaseModel):
     players: Dict[str, PlayerState] = {}
     zombies: List[ZombieState] = []
     walls: List[WallState] = []
+    containers: List[ContainerState] = []
     width: int = 800
     height: int = 600

--- a/backend/app/game/world.py
+++ b/backend/app/game/world.py
@@ -6,49 +6,221 @@ import math
 import random
 from typing import List, Tuple
 
-from .models import WallState, ZombieState, PlayerState
+from .models import (
+    CONTAINER_LOOT,
+    WALL_MATERIALS,
+    ContainerState,
+    PlayerState,
+    WallState,
+    ZombieState,
+)
 
 SEGMENT_SIZE = 40
+FIRE_ZOMBIE_CHANCE = 0.2
+ZOMBIE_WAVE_SIZE = 5
 
 
-def generate_world(
-    width: int, height: int
-) -> Tuple[List[WallState], List[ZombieState], dict]:
-    """Create the initial walls, zombies and spawn door."""
+# ---------------------------------------------------------------------------
+# World generation helpers
+# ---------------------------------------------------------------------------
+
+
+def create_wall(gx: int, gy: int, material: str | None = None) -> WallState:
+    """Create a ``WallState`` at the given grid coordinate."""
+
+    mat = material or random.choice(list(WALL_MATERIALS.keys()))
+    hp = WALL_MATERIALS[mat]["hp"]
+    return WallState(
+        x=gx * SEGMENT_SIZE,
+        y=gy * SEGMENT_SIZE,
+        size=SEGMENT_SIZE,
+        material=mat,
+        hp=hp,
+        max_hp=hp,
+    )
+
+
+def generate_store_walls(width: int, height: int) -> List[WallState]:
+    """Generate the hardware store style layout."""
 
     walls: List[WallState] = []
     grid_w = width // SEGMENT_SIZE
     grid_h = height // SEGMENT_SIZE
 
-    for x in range(grid_w):
-        walls.append(
-            WallState(x=x * SEGMENT_SIZE, y=0, size=SEGMENT_SIZE, material="steel")
-        )
-        walls.append(
-            WallState(
-                x=x * SEGMENT_SIZE,
-                y=(grid_h - 1) * SEGMENT_SIZE,
-                size=SEGMENT_SIZE,
-                material="steel",
-            )
-        )
-    for y in range(grid_h):
-        walls.append(
-            WallState(x=0, y=y * SEGMENT_SIZE, size=SEGMENT_SIZE, material="steel")
-        )
-        walls.append(
-            WallState(
-                x=(grid_w - 1) * SEGMENT_SIZE,
-                y=y * SEGMENT_SIZE,
-                size=SEGMENT_SIZE,
-                material="steel",
-            )
-        )
+    def clamp(v: int, mn: int, mx: int) -> int:
+        return max(mn, min(mx, v))
 
-    door = {"x": width / 2, "y": SEGMENT_SIZE}
-    zombies = [ZombieState(x=door["x"], y=door["y"], facing_x=0, facing_y=1)]
+    def add_vertical(gx: int, gy1: int, gy2: int) -> None:
+        gx_c = clamp(gx, 0, grid_w - 1)
+        gy1_c = clamp(gy1, 0, grid_h - 1)
+        gy2_c = clamp(gy2, 0, grid_h - 1)
+        for y in range(gy1_c, gy2_c + 1):
+            walls.append(create_wall(gx_c, y))
 
-    return walls, zombies, door
+    def add_horizontal(gy: int, gx1: int, gx2: int) -> None:
+        gy_c = clamp(gy, 0, grid_h - 1)
+        gx1_c = clamp(gx1, 0, grid_w - 1)
+        gx2_c = clamp(gx2, 0, grid_w - 1)
+        for x in range(gx1_c, gx2_c + 1):
+            walls.append(create_wall(x, gy_c))
+
+    def add_room(x: int, y: int, w: int, h: int) -> None:
+        for gx in range(x, x + w):
+            for gy in range(y, y + h):
+                if gx == x + w // 2 and gy == y + h - 1:
+                    continue
+                if gx in (x, x + w - 1) or gy in (y, y + h - 1):
+                    walls.append(create_wall(gx, gy))
+
+    v_spacing = max(6, grid_w // 4)
+    v_positions: List[int] = []
+    for gx in range(2, grid_w - 2, v_spacing):
+        v_positions.append(gx)
+        y = 2
+        while y < grid_h - 4:
+            length = 4 + random.randint(0, 2)
+            add_vertical(gx, y, min(y + length - 1, grid_h - 4))
+            y += length + 3 + random.randint(0, 1)
+
+    h_spacing = max(8, grid_h // 5)
+    for gy in range(4, grid_h - 3, h_spacing):
+        x = 2
+        while x < grid_w - 4:
+            length = 4 + random.randint(0, 2)
+            add_horizontal(gy, x, min(x + length - 1, grid_w - 4))
+            x += length + 4 + random.randint(0, 2)
+
+    for gx in v_positions:
+        if random.random() < 0.4:
+            y = 2 + random.randint(0, max(1, grid_h - 8))
+            add_horizontal(y, gx - 1, gx + 1)
+            add_horizontal(y + 1, gx - 1, gx + 1)
+
+    room_count = 1 + random.randint(0, 1)
+    for _ in range(room_count):
+        rw = min(3 + random.randint(0, 2), grid_w - 2)
+        rh = min(3 + random.randint(0, 2), grid_h - 2)
+        if rw < 3 or rh < 3:
+            continue
+        start_x = 1 + random.randint(0, grid_w - rw - 1)
+        start_y = 1 + random.randint(0, grid_h - rh - 1)
+        add_room(start_x, start_y, rw, rh)
+
+    return walls
+
+
+def random_open_position(
+    width: int, height: int, walls: List[WallState]
+) -> Tuple[float, float]:
+    """Return a random position not colliding with walls."""
+
+    attempts = 0
+    while True:
+        x = random.random() * width
+        y = random.random() * height
+        colliding = any(
+            w.x <= x <= w.x + w.size and w.y <= y <= w.y + w.size for w in walls
+        )
+        if not colliding or attempts > 20:
+            return x, y
+        attempts += 1
+
+
+def create_container(x: float, y: float) -> ContainerState:
+    return ContainerState(x=x, y=y)
+
+
+def spawn_containers(
+    width: int, height: int, walls: List[WallState], count: int = 3
+) -> List[ContainerState]:
+    containers = []
+    for _ in range(count):
+        px, py = random_open_position(width, height, walls)
+        containers.append(create_container(px, py))
+    return containers
+
+
+def create_spawn_door(width: int, height: int, walls: List[WallState]) -> dict:
+    door = None
+    inside = None
+    while True:
+        edge = random.randint(0, 3)
+        if edge == 0:
+            door = {"x": random.random() * width, "y": 0}
+            inside = {"x": door["x"], "y": SEGMENT_SIZE}
+        elif edge == 1:
+            door = {"x": random.random() * width, "y": height}
+            inside = {"x": door["x"], "y": height - SEGMENT_SIZE}
+        elif edge == 2:
+            door = {"x": 0, "y": random.random() * height}
+            inside = {"x": SEGMENT_SIZE, "y": door["y"]}
+        else:
+            door = {"x": width, "y": random.random() * height}
+            inside = {"x": width - SEGMENT_SIZE, "y": door["y"]}
+        colliding = any(
+            wall.x <= door["x"] <= wall.x + wall.size
+            and wall.y <= door["y"] <= wall.y + wall.size
+            for wall in walls
+        ) or any(
+            wall.x <= inside["x"] <= wall.x + wall.size
+            and wall.y <= inside["y"] <= wall.y + wall.size
+            for wall in walls
+        )
+        if not colliding:
+            break
+    return door
+
+
+def create_zombie(x: float, y: float, variant: str = "normal") -> ZombieState:
+    return ZombieState(x=x, y=y, variant=variant)
+
+
+def spawn_zombie_wave(
+    count: int,
+    door: dict,
+    width: int,
+    height: int,
+    variant: str = "normal",
+    walls: List[WallState] | None = None,
+) -> List[ZombieState]:
+    walls = walls or []
+    spawn_x = min(max(door["x"], 1), width - 1)
+    spawn_y = min(max(door["y"], 1), height - 1)
+    zombies: List[ZombieState] = []
+    for _ in range(count):
+        attempts = 0
+        while True:
+            angle = random.random() * math.pi * 2
+            dist = random.random() * (SEGMENT_SIZE / 2)
+            pos_x = min(max(spawn_x + math.cos(angle) * dist, 1), width - 1)
+            pos_y = min(max(spawn_y + math.sin(angle) * dist, 1), height - 1)
+            if not any(
+                w.x <= pos_x <= w.x + w.size and w.y <= pos_y <= w.y + w.size
+                for w in walls
+            ) and not any(math.hypot(z.x - pos_x, z.y - pos_y) < 10 for z in zombies):
+                zombies.append(create_zombie(pos_x, pos_y, variant))
+                break
+            attempts += 1
+            if attempts > 20:
+                break
+    return zombies
+
+
+# ---------------------------------------------------------------------------
+# Public world generation entry points
+# ---------------------------------------------------------------------------
+
+
+def generate_world(
+    width: int, height: int
+) -> Tuple[List[WallState], List[ZombieState], List[ContainerState], dict]:
+    """Create walls, zombies, containers and a spawn door."""
+
+    walls = generate_store_walls(width, height)
+    door = create_spawn_door(width, height, walls)
+    zombies = spawn_zombie_wave(ZOMBIE_WAVE_SIZE, door, width, height, "normal", walls)
+    containers = spawn_containers(width, height, walls)
+    return walls, zombies, containers, door
 
 
 def spawn_player(
@@ -56,14 +228,7 @@ def spawn_player(
 ) -> Tuple[float, float]:
     """Return a random open position for a new player."""
 
-    while True:
-        x = random.random() * width
-        y = random.random() * height
-        colliding = any(
-            w.x <= x <= w.x + w.size and w.y <= y <= w.y + w.size for w in walls
-        )
-        if not colliding:
-            return x, y
+    return random_open_position(width, height, walls)
 
 
 def update_zombies(

--- a/backend/tests/test_world_generation.py
+++ b/backend/tests/test_world_generation.py
@@ -10,3 +10,4 @@ def test_world_generated_on_session_create():
     session = GameSession()
     assert len(session.state.walls) > 0
     assert len(session.state.zombies) > 0
+    assert len(session.state.containers) > 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,9 +35,10 @@ This project is split into separate frontend and backend components.
   complete game state to all connected clients roughly 60 times per second.
 
 All map generation and AI logic now live exclusively on the backend. When a game
-session is created the server generates the walls, spawn door and initial
-zombies exactly once. Clients merely render this shared state and relay player
-input.
+session is created the server procedurally generates the hardware store layout
+including shelves and loot containers. It also creates a spawn door and an
+initial wave of zombies. Clients merely render this shared state and relay
+player input.
 
 Both sides communicate via HTTP or WebSockets. The repository emphasizes clear separation of concerns and maintainable code.
 The gameplay state is managed by a `GameScene` class in `frontend/src/scenes/game-scene.js`. It owns the player, zombies and other world objects and exposes `update` and `render` methods used by `main.js`.

--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -2,7 +2,9 @@
 
 This repository includes a minimal zombie survival demo to showcase basic
 canvas-based gameplay. The game world is generated on the backend so every
-connected client sees the same layout and AI behavior.
+connected client sees the same layout and AI behavior. The server now builds the
+full hardware store map with shelves and searchable containers so the client can
+render a rich environment from the authoritative state.
 
 ## Running the Example
 


### PR DESCRIPTION
## Summary
- port frontend data models to backend `models.py`
- implement hardware store layout generation in `world.py`
- initialize `GameSession` with full world state including containers
- update docs to describe new server generated map
- extend tests for container creation

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871fc4be7a883239beb8c5f99e140b8