### PR TITLE
Fix looted shelves fade and message positioning

### DIFF
--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -61,7 +61,7 @@ Press **C** to open the crafting menu at any time. Only recipes for which you ow
 
 ## Containers
 
-Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box now contains **Scrap Metal**, **Duct Tape**, **Nails**, or a **Medkit** with equal probability. If there is room in your hotbar or inventory the item is added automatically. Otherwise a brief "Inventory Full" message appears. Opened boxes appear faded so you know they have been searched.
+Cardboard boxes are scattered around the arena. They are now rendered using a box icon instead of a brown square. Stand next to one and hold **F** to loot it. A progress bar appears in the center of the screen for three seconds while you search. When the bar completes the box opens. Each box now contains **Scrap Metal**, **Duct Tape**, **Nails**, or a **Medkit** with equal probability. If there is room in your hotbar or inventory the item is added automatically. Otherwise a brief "Inventory Full" message appears. Opened boxes appear faded so you know they have been searched. Loot notifications now appear just above the hotbar so they remain visible.
 
 Shelves can now be searched the same way. Stand beside a shelf segment, face it, and hold **F** to rummage through. Searching takes time and each shelf can only be looted once. Looted shelves fade just like opened boxes. Shelves usually contain nothing, but very rarely yield extra crafting materials like **Scrap Metal**, **Duct Tape**, **Nails**, **Plastic Fragments**, **Wood Planks**, or **Steel Plates**.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -218,7 +218,7 @@
       id="pickupMessage"
       style="
         position: absolute;
-        bottom: 40px;
+        bottom: 80px;
         left: 50%;
         transform: translateX(-50%);
         color: white;

--- a/frontend/src/systems/rendering-system.js
+++ b/frontend/src/systems/rendering-system.js
@@ -61,14 +61,14 @@ export function render(ctx, state) {
 
   walls.forEach((w) => {
     const img = WALL_IMAGES[w.material];
+    ctx.globalAlpha = w.opened ? 0.5 : 1;
     if (img && img.complete) {
-      ctx.globalAlpha = w.opened ? 0.5 : 1;
       ctx.drawImage(img, w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
-      ctx.globalAlpha = 1;
     } else {
       ctx.fillStyle = "gray";
       ctx.fillRect(w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);
     }
+    ctx.globalAlpha = 1;
     if (w.damageTimer > 0) {
       ctx.fillStyle = "rgba(255,0,0,0.5)";
       ctx.fillRect(w.x, w.y, SEGMENT_SIZE, SEGMENT_SIZE);


### PR DESCRIPTION
## Summary
- apply global alpha to shelves even before images load
- move pickup message above the hotbar for visibility
- document HUD change in zombie game docs

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732741f374832397bc131c763f8cb8