### PR TITLE
Fix looted shelf visuals and HUD artifact

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,8 @@ The client now compares each update against the previous one to detect newly
 opened containers and shelves. When a loot action resolves, the HUD briefly
 displays a message such as "You found Wood" or "Container is empty." Loot
 messages appear with a dark translucent background so they remain readable on
-any backdrop. Containers and shelves flagged as opened are rendered at 50%
+any backdrop. When no message is active the element is hidden entirely to avoid
+leftover artifacts. Containers and shelves flagged as opened are rendered at 50%
 opacity so players can easily tell which ones have been searched. The local
 inventory object is synchronized with the authoritative counts so new items
 immediately appear in the hotbar and inventory grid.

--- a/frontend/src/components/hud.js
+++ b/frontend/src/components/hud.js
@@ -1,19 +1,40 @@
+/**
+ * Create the HUD overlay shown during gameplay.
+ *
+ * @param {{pickupMsg:HTMLElement, waveCounterDiv:HTMLElement}} param0
+ *   Elements used to display pickup text and the current wave.
+ * @returns {{
+ *   showPickupMessage: Function,
+ *   update: Function,
+ *   clearPickupMessage: Function,
+ *   setWave: Function,
+ *   showWaveCounter: Function,
+ *   hideWaveCounter: Function,
+ *   render: Function,
+ * }} HUD control methods.
+ */
 export function createHUD({ pickupMsg, waveCounterDiv }) {
   let pickupTimer = 0;
+  pickupMsg.style.display = "none";
 
   function showPickupMessage(text) {
     pickupMsg.textContent = text;
+    pickupMsg.style.display = "block";
     pickupTimer = 60;
   }
 
   function clearPickupMessage() {
     pickupMsg.textContent = "";
+    pickupMsg.style.display = "none";
     pickupTimer = 0;
   }
   function update() {
     if (pickupTimer > 0) {
       pickupTimer--;
-      if (pickupTimer === 0) pickupMsg.textContent = "";
+      if (pickupTimer === 0) {
+        pickupMsg.textContent = "";
+        pickupMsg.style.display = "none";
+      }
     }
   }
 

--- a/frontend/src/scenes/game-scene.js
+++ b/frontend/src/scenes/game-scene.js
@@ -339,12 +339,14 @@ export class GameScene {
     ctx.translate(-this.camera.x, -this.camera.y);
     this.state.walls.forEach((w) => {
       const img = WALL_IMAGES[w.material];
+      ctx.globalAlpha = w.opened ? 0.5 : 1;
       if (img && img.complete) {
         ctx.drawImage(img, w.x, w.y, w.size, w.size);
       } else {
         ctx.fillStyle = "gray";
         ctx.fillRect(w.x, w.y, w.size, w.size);
       }
+      ctx.globalAlpha = 1;
     });
     if (this.state.door) {
       ctx.fillStyle = "brown";


### PR DESCRIPTION
## Summary
- fade opened shelves just like boxes when rendering
- hide pickup text element when not in use
- document HUD hiding behavior in architecture docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68732d5dcd908323a5694e3de94eeffb