### PR TITLE
Enable LAN play

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run dev
 ```bash
 cd backend
 pip install -r requirements.txt
-uvicorn app.main:app --reload
+uvicorn app.main:app --host 0.0.0.0 --reload
 ```
 
 ## Contributing

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,7 +8,7 @@ Install dependencies and run the server:
 
 ```bash
 pip install -r requirements.txt
-uvicorn app.main:app --reload
+uvicorn app.main:app --host 0.0.0.0 --reload
 ```
 
-The API will be available at `http://localhost:8000`.
+The API will be available at `http://<your-ip>:8000`.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,3 +51,15 @@ async def game_loop() -> None:
 app.include_router(routes_health.router)
 app.include_router(routes_game.router)
 app.include_router(websocket_routes.router)
+
+
+def start() -> None:
+    """Launch the development server bound to all network interfaces."""
+
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)
+
+
+if __name__ == "__main__":
+    start()

--- a/backend/tests/test_run_main.py
+++ b/backend/tests/test_run_main.py
@@ -1,0 +1,15 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import main
+
+
+def test_start_invokes_uvicorn_run():
+    with patch("uvicorn.run") as run_mock:
+        main.start()
+        run_mock.assert_called_with(
+            "app.main:app", host="0.0.0.0", port=8000, reload=True
+        )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ This project is split into separate frontend and backend components.
   can be created via the `http://${hostname}:8000/api/games` HTTP endpoint. The
   service began with a simple health check but is structured for future
   realtime features. During development the backend enables CORS for
-  `http://localhost:3000` so the Vite server can call the API. The Clients first see a lobby screen that can create or
+  the hostname serving the frontend so the Vite server or built files can call the API. The Clients first see a lobby screen that can create or
   join a session using the same `http://${hostname}:8000/api/games` endpoint.
   The lobby passes the chosen `gameId` to a
   `startGame(gameId)` function which constructs a `GameScene`, attaches keyboard

--- a/docs/zombie_game.md
+++ b/docs/zombie_game.md
@@ -16,7 +16,7 @@ npm install
 npm run dev
 ```
 
-The game runs entirely in the browser. Open `http://localhost:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. Five basic zombies enter through this door at the beginning of **Wave&nbsp;1**, shown in a counter at the top right which now uses black text for visibility. Once all five are defeated a Victory screen appears with a button to play again.
+The game runs entirely in the browser. Open `http://localhost:3000` or `http://<your-ip>:3000` and you will be greeted with a simple main menu. Click **Start Game** to jump into the action. Use the arrow keys or WASD to move the player character, now drawn using a full sprite rather than a green dot. Zombies also use sprites that rotate to match their movement direction. The player still spawns randomly, but zombies now emerge from a single door placed along the outer edge of the arena. Five basic zombies enter through this door at the beginning of **Wave&nbsp;1**, shown in a counter at the top right which now uses black text for visibility. Once all five are defeated a Victory screen appears with a button to play again.
 Zombies push away from each other as they move, so only one can occupy a grid space at a time and new zombies won't spawn on top of existing ones.
 The spawn door is guaranteed to have an open space just inside the arena so
 fresh zombies are never trapped when they appear.


### PR DESCRIPTION
## Summary
- run backend on 0.0.0.0 for LAN access
- test the new `start` helper
- document how to start the server for LAN
- note new dynamic CORS and LAN URLs in docs

## Testing
- `npm test --silent --prefix frontend`
- `pytest -q backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6873f12369048323ac0f70938b22ee3b