### PR TITLE
Allow CORS from LAN hosts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,3 +12,9 @@ uvicorn app.main:app --host 0.0.0.0 --reload
 ```
 
 The API will be available at `http://<your-ip>:8000`.
+
+### CORS
+
+During development the server accepts requests from any device on your local
+network. Access the frontend using `http://localhost:3000` or your machine's IP
+address and it will be able to call the API without CORS errors.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,10 +22,15 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+# Accept requests from the Vite dev server whether it is accessed via
+# localhost or another device on the local network. The explicit
+# `allow_origins` entry covers the common localhost case while the
+# regular expression matches any IPv4 address on port 3000.
 origins = ["http://localhost:3000"]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
+    allow_origin_regex=r"http://(?:localhost|\d{1,3}(?:\.\d{1,3}){3}):3000",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -18,3 +18,11 @@ def test_cors_headers_on_post():
             response.headers.get("access-control-allow-origin")
             == "http://localhost:3000"
         )
+
+        ip_origin = "http://192.168.0.42:3000"
+        response = client.post(
+            "/api/games",
+            headers={"Origin": ip_origin},
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == ip_origin

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ This project is split into separate frontend and backend components.
   can be created via the `http://${hostname}:8000/api/games` HTTP endpoint. The
   service began with a simple health check but is structured for future
   realtime features. During development the backend enables CORS for
-  the hostname serving the frontend so the Vite server or built files can call the API. The Clients first see a lobby screen that can create or
+  any local origin so the Vite server can be accessed via `localhost` or a local IP address. This allows testing from phones or other computers on the same Wi-Fi. The Clients first see a lobby screen that can create or
   join a session using the same `http://${hostname}:8000/api/games` endpoint.
   The lobby passes the chosen `gameId` to a
   `startGame(gameId)` function which constructs a `GameScene`, attaches keyboard


### PR DESCRIPTION
## Summary
- permit LAN IPs in backend CORS policy
- document new policy in architecture docs and backend README
- test CORS with a LAN IP

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873fb26c3788323bc06af8c5e9fea4d