### PR TITLE
Implement server-side crafting and hotbar item usage

### DIFF
--- a/backend/app/api/websocket_routes.py
+++ b/backend/app/api/websocket_routes.py
@@ -23,7 +23,13 @@ async def game_ws(websocket: WebSocket, game_id: str) -> None:
     try:
         while True:
             data = await websocket.receive_json()
-            session.update_player_state(player_id, data)
+            msg_type = data.get("type")
+            if msg_type == "craft_item":
+                session.craft_item(player_id, data.get("itemId", ""))
+            elif msg_type == "use_item":
+                session.use_item(player_id, data.get("itemId", ""))
+            else:
+                session.update_player_state(player_id, data)
     except WebSocketDisconnect:
         session.remove_player(player_id)
         print(f"Player {player_id} disconnected from game {game_id}")

--- a/backend/app/game/manager.py
+++ b/backend/app/game/manager.py
@@ -218,6 +218,26 @@ class GameSession:
             player.facing_x = float(facing_x)
             player.facing_y = float(facing_y)
 
+    def craft_item(self, player_id: str, item_id: str) -> None:
+        """Attempt to craft ``item_id`` for the specified player."""
+
+        from .world import craft_item as _craft
+
+        player = self.state.players.get(player_id)
+        if not player:
+            return
+        _craft(player, item_id)
+
+    def use_item(self, player_id: str, item_id: str) -> None:
+        """Use ``item_id`` from the player's inventory."""
+
+        from .world import use_item as _use
+
+        player = self.state.players.get(player_id)
+        if not player:
+            return
+        _use(player, item_id)
+
     def get_game_state(self) -> GameState:
         """Return the current game state."""
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,11 @@ data to these sprites so walls, containers and characters use the textures found
 in the `assets/` directory. The inventory UI now reads the authoritative player
 state sent over the WebSocket to populate its slots and hotbar.
 
+Crafting is server-authoritative as well. Clicking a recipe sends
+`{"type": "craft_item", "itemId": "..."}` so the backend can verify materials
+before adding the result to the player's inventory. Using an item dispatches a
+similar `use_item` message ensuring all effects occur on the server.
+
 `GameScene` automatically scales the canvas using the browser window height but
 never above a scale of `1` so tall monitors don't zoom in. A small camera
 keeps the player centered and clamps the view to the world bounds so wide

--- a/frontend/src/components/crafting-ui.js
+++ b/frontend/src/components/crafting-ui.js
@@ -1,9 +1,26 @@
 import { countItem } from "../systems/inventory-system.js";
-import { RECIPES, canCraft, craftRecipe } from "../systems/crafting-system.js";
+import { RECIPES, canCraft } from "../systems/crafting-system.js";
 
+/**
+ * Build and manage the crafting menu UI.
+ *
+ * @param {object} elements - DOM references used by the UI.
+ * @param {HTMLElement} elements.craftingDiv - Root crafting element.
+ * @param {HTMLElement} elements.craftingList - Container for recipe entries.
+ * @param {HTMLElement} elements.craftingBar - Draggable bar element.
+ * @param {HTMLElement} elements.craftingClose - Close button element.
+ * @param {{left:number|null,top:number|null}} elements.craftingPos - Saved menu position.
+ * @param {object} callbacks - Rendering callbacks.
+ * @param {Function} callbacks.renderInventory - Rerender the inventory UI.
+ * @param {Function} callbacks.renderHotbar - Rerender the hotbar UI.
+ * @param {Function} sendCraftMessage - Function used to notify the server when crafting.
+ * @returns {{renderCrafting:Function,toggleCrafting:Function,isOpen:Function}}
+ *   Helper methods for controlling the crafting UI.
+ */
 export function createCraftingUI(
   { craftingDiv, craftingList, craftingBar, craftingClose, craftingPos },
   { renderInventory, renderHotbar },
+  sendCraftMessage,
 ) {
   let open = false;
 
@@ -61,13 +78,9 @@ export function createCraftingUI(
       if (canCraft(inventory, r)) {
         container.style.cursor = "pointer";
         container.addEventListener("click", () => {
-          const added = craftRecipe(inventory, r);
-          if (!added && worldItems) {
-            worldItems.push({ x: player.x, y: player.y, type: r.id, count: 1 });
+          if (typeof sendCraftMessage === "function") {
+            sendCraftMessage(r.id);
           }
-          if (renderInventory) renderInventory();
-          renderCrafting(inventory, player, itemIcons, worldItems);
-          if (renderHotbar) renderHotbar();
         });
       }
       craftingList.appendChild(container);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -31,6 +31,7 @@ export function startGame(gameId) {
   window.addEventListener("mousemove", (e) =>
     scene.setMousePos(e.clientX, e.clientY),
   );
+  scene.canvas.addEventListener("mousedown", (e) => scene.handleMouseDown(e));
   scene.canvas.addEventListener("contextmenu", (e) => e.preventDefault());
 
   requestAnimationFrame(gameLoop);

--- a/frontend/tests/input.test.js
+++ b/frontend/tests/input.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import { GameScene } from "../src/scenes/game-scene.js";
+import { addItem } from "../src/systems/inventory-system.js";
 
 function setupScene() {
   const dom = new JSDOM(`<!DOCTYPE html><canvas id="gameCanvas"></canvas>
@@ -76,4 +77,23 @@ test("tab sends attack action", () => {
   scene.ws = { readyState: 1, send: (msg) => (sent = JSON.parse(msg)) };
   scene.handleKeyDown({ key: "Tab" });
   assert.strictEqual(sent.action, "attack");
+});
+
+test("number keys change active hotbar slot", () => {
+  const scene = setupScene();
+  addItem(scene.inventory, "core", 1);
+  scene.handleKeyDown({ key: "2" });
+  assert.strictEqual(scene.inventory.active, 1);
+});
+
+test("left click sends use_item message", () => {
+  const scene = setupScene();
+  scene.playerId = "p";
+  scene.state.players = { p: { x: 0, y: 0 } };
+  addItem(scene.inventory, "medkit", 1);
+  let sent = null;
+  scene.ws = { readyState: 1, send: (msg) => (sent = JSON.parse(msg)) };
+  scene.handleMouseDown({ button: 0 });
+  assert.strictEqual(sent.type, "use_item");
+  assert.strictEqual(sent.itemId, "medkit");
 });


### PR DESCRIPTION
## Summary
- wire up craft_item and use_item WebSocket messages
- implement crafting and item usage logic on the backend
- allow hotbar selection with number keys and left‑click item usage
- send crafting requests from the crafting UI
- document new network flow
- add unit tests for new functionality

## Testing
- `npm --prefix frontend test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c2da34c48323883b01b06eaf8516